### PR TITLE
deleted the "content" field to avoid dupilcation of output

### DIFF
--- a/axiomatic_mcp/servers/documents/server.py
+++ b/axiomatic_mcp/servers/documents/server.py
@@ -39,7 +39,6 @@ async def document_to_markdown(
     markdown: str = response["markdown"]
     name = file_path.stem + ".md"
     return ToolResult(
-        content=[TextContent(type="text", text=f"Generated markdown for: {name}\n\n```markdown\n{markdown}\n```")],
         structured_content={
             "suggestions": [{"type": "create_file", "path": name, "content": markdown, "description": f"Create {name} with the generated markdown"}]
         },


### PR DESCRIPTION
Related to bug reported by Frank K:

<img width="1702" height="296" alt="image" src="https://github.com/user-attachments/assets/1478cfeb-05a7-4112-9c75-3057180fde58" />

simplifying the output of the tool fixed to problem - at least it appears so while testing locally with Cursor. However, it seems like Claude Code did not detect the local changes and idk how to test it locally.

Bug was reported in Claude code repo: https://github.com/anthropics/claude-code/issues/4002