### PR TITLE
Extract images with markdown using the documents MCP

### DIFF
--- a/axiomatic_mcp/servers/documents/server.py
+++ b/axiomatic_mcp/servers/documents/server.py
@@ -1,5 +1,7 @@
 """Documents MCP server for filesystem document operations."""
 
+import base64
+import re
 from pathlib import Path
 from typing import Annotated
 
@@ -20,7 +22,11 @@ mcp = FastMCP(
 
 @mcp.tool(
     name="document_to_markdown",
-    description="Convert a PDF document to markdown using Axiomatic's advanced OCR.",
+    description="""
+    Convert a PDF document to markdown using Axiomatic's advanced OCR.
+    The output will be a markdown file with the same name as the input file,
+    and the images will be saved in the same directory as the input file.
+    """,
     tags=["document", "filesystem", "analyze"],
 )
 async def document_to_markdown(
@@ -34,11 +40,22 @@ async def document_to_markdown(
         with Path.open(name, "w", encoding="utf-8") as f:
             f.write(markdown)
 
+        for image_name, base64_string in response.images.items():
+            image_path = file_path.parent / image_name
+
+            if base64_string.startswith("data:image/"):
+                image_data = re.match(r"data:image/[^;]+;base64,(.*)", base64_string).group(1)
+            else:
+                image_data = base64_string
+
+            with Path.open(image_path, "wb") as image_file:
+                image_file.write(base64.b64decode(image_data))
+
         return ToolResult(
             content=[
                 TextContent(
                     type="text",
-                    text=f"Generated markdown for: {name}\n\n```markdown\n{markdown}\n```",
+                    text=f"Generated markdown for: {name}\nImages saved in: {file_path.parent}\n\n```markdown\n{markdown}\n```",
                 )
             ],
         )

--- a/axiomatic_mcp/shared/documents/pdf_to_markdown.py
+++ b/axiomatic_mcp/shared/documents/pdf_to_markdown.py
@@ -25,13 +25,13 @@ async def pdf_to_markdown(file_path: Path) -> ParseResponse:
 
     file_content = await asyncio.to_thread(file_path.read_bytes)
     files = {"file": (file_path.name, file_content, "application/pdf")}
-    data = {"method": "mistral", "ocr": False, "layout_model": "doclayout_yolo"}
+    params = {"method": "mistral", "ocr": False, "layout_model": "doclayout_yolo"}
 
     response = await asyncio.to_thread(
         AxiomaticAPIClient().post,
         "/document/parse",
         files=files,
-        data=data,
+        params=params,
     )
 
     return ParseResponse(**response)


### PR DESCRIPTION
Mahdi and Frank K have mentioned that they would like to have the images downloaded along with the markdown when using the documet_to_md MCP server.

I this PR I add a simple way of converting the base64 encoded images to files and save them in the directory where the input file is located. 

I also fixed the pdf_to_markdown shared function, the API call was not using mistral since it was not passed as a parameter. 

I tested with both Cursor and Claude Code:

<img width="1019" height="762" alt="image" src="https://github.com/user-attachments/assets/d1c9825a-6ab3-46cb-b8a6-f5434b6c0f89" />

I know this may not be useful in the Web Platform but could help the MCPs that run in the console, let me know if you have any questions or inquires. 