### PR TITLE
Release: Add images in document_to_markdown tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiomatic-mcp"
-version = "0.0.4"
+version = "0.0.5"
 description = "Modular MCP servers for Axiomatic_AI"
 authors = [{name = "Axiomatic Team", email = "developers@axiomatic.ai"}]
 readme = "README.md"


### PR DESCRIPTION
This PR adds support to get images from the parsed PDF files in document_to_markdown tool for the documents server.

Features:
- The **document_to_markdown** MCP tool now returns the image files along with the markdown for a given PDF file. The markdown file and the images are saved in the same path where the input PDF file is located. 