### PR TITLE
feat: add quickstart that installs all tools in one server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev test format clean
+.PHONY: install dev test format clean run inspect
 
 install:
 	@command -v uv >/dev/null 2>&1 || (echo "Installing uv..." && curl -LsSf https://astral.sh/uv/install.sh | sh)
@@ -24,3 +24,9 @@ clean:
 	@rm -rf build/ dist/ *.egg-info .pytest_cache .ruff_cache .mypy_cache
 	@find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	@echo "✅ Cleaned build artifacts"
+
+run:
+	@uv run python -m axiomatic_mcp
+
+inspect:
+	@npx @modelcontextprotocol/inspector uv run python -m axiomatic_mcp

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	@command -v uv >/dev/null 2>&1 || (echo "Installing uv..." && curl -LsSf https://astral.sh/uv/install.sh | sh)
 	@echo "Installing ax-mcp..."
 	@uv pip install -e .
-	@echo "✅ Installation complete! Run 'axiomatic-pic' to start the server."
+	@echo "✅ Installation complete!"
 
 install-dev:
 	@command -v uv >/dev/null 2>&1 || (echo "Installing uv..." && curl -LsSf https://astral.sh/uv/install.sh | sh)

--- a/README.dev.md
+++ b/README.dev.md
@@ -88,11 +88,13 @@ def my_tool():
 axiomatic-mydomain = "axiomatic_mcp.servers.my_domain:main"
 ```
 
-5. Update README.md with instructions on installing your server. You can generate the "Add to cursor" button [here](https://docs.cursor.com/en/tools/developers)
+5. Add server to the servers array in `axiomatic_mcp/servers/__init__.py`
 
-6. Don't forget to link to your server's README.md in the main project README.md
+6. Update README.md with instructions on installing your server. You can generate the "Add to cursor" button [here](https://docs.cursor.com/en/tools/developers)
 
-7. Creating **Add to Cursor** button:
+7. Don't forget to link to your server's README.md in the main project README.md
+
+8. Creating **Add to Cursor** button:
    Copy your MCP client configuration and paste it there:
    https://docs.cursor.com/en/tools/developers#generate-install-link
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Axiomatic MCP Servers
 
+![Join Discord](https://img.shields.io/discord/1414600199577534516)
+
 MCP (Model Context Protocol) servers that provide AI assistants with access to the Axiomatic_AI Platform - a suite of advanced tools for scientific computing, document processing, and photonic circuit design.
 
 ## Available Servers

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axiomatic MCP Servers
 
-[![Static Badge](https://img.shields.io/badge/Join%20Discord-6EB700?style=flat)](https://discord.gg/KKU97ZR5)
+[![Static Badge](https://img.shields.io/badge/Join%20Discord-5865f2?style=flat)](https://discord.gg/KKU97ZR5)
 
 MCP (Model Context Protocol) servers that provide AI assistants with access to the Axiomatic_AI Platform - a suite of advanced tools for scientific computing, document processing, and photonic circuit design.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axiomatic MCP Servers
 
-![Join Discord](https://img.shields.io/discord/1414600199577534516)
+[![Static Badge](https://img.shields.io/badge/Join%20Discord-6EB700?style=flat)](https://discord.gg/KKU97ZR5)
 
 MCP (Model Context Protocol) servers that provide AI assistants with access to the Axiomatic_AI Platform - a suite of advanced tools for scientific computing, document processing, and photonic circuit design.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,81 @@
 
 MCP (Model Context Protocol) servers that provide AI assistants with access to the Axiomatic_AI Platform - a suite of advanced tools for scientific computing, document processing, and photonic circuit design.
 
-## Available Servers
+## 🚀 Quickstart
+
+### System requirements
+
+- Python
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+
+#### 1. Get an API key
+
+[![Static Badge](https://img.shields.io/badge/Get%20your%20API%20key-6EB700?style=flat)](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform)
+
+#### 2. Configure your client
+
+<details>
+<summary><strong>⚡ Claude Code</strong></summary>
+
+```bash
+claude mcp add axiomatic-mcp --command "uvx --from axiomatic-mcp all" --env AXIOMATIC_API_KEY=your-api-key-here
+```
+
+</details>
+
+<details>
+<summary><strong>🔷 Cursor</strong></summary>
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=axiomatic-mcp&config=eyJjb21tYW5kIjoidXZ4IC0tZnJvbSBheGlvbWF0aWMtbWNwIGFsbCIsImVudiI6eyJBWElPTUFUSUNfQVBJX0tFWSI6InlvdXItYXBpLWtleS1oZXJlIn19)
+
+</details>
+
+<details>
+<summary><strong>🤖 Claude Desktop</strong></summary>
+
+1. Open Claude Desktop settings → Developer → Edit MCP config
+2. Add this configuration:
+
+```json
+{
+  "mcpServers": {
+    "axiomatic-mcp": {
+      "command": "uvx",
+      "args": ["--from", "axiomatic-mcp", "all"],
+      "env": {
+        "AXIOMATIC_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+3. Restart Claude Desktop
+
+</details>
+
+<details>
+<summary><strong>🌊 Other MCP Clients</strong></summary>
+
+Use this server configuration:
+
+```json
+{
+  "command": "uvx",
+  "args": ["--from", "axiomatic-mcp", "all"],
+  "env": {
+    "AXIOMATIC_API_KEY": "your-api-key-here"
+  }
+}
+```
+
+</details>
+
+> **Note:** This installs all tools under one server and may cause issues with some clients. If you experience problems, install individual servers instead.
+
+## Individual servers
+
+You may find more information about each server and how to install them individually in their own READMEs.
 
 ### 🖌️ [AxEquationExplorer](https://github.com/Axiomatic-AI/ax-mcp/tree/main/axiomatic_mcp/servers/equations/)
 
@@ -29,62 +103,6 @@ Design photonic integrated circuits using natural language descriptions.
 ### 📊 [AxPlotToData](https://github.com/Axiomatic-AI/ax-mcp/tree/main/axiomatic_mcp/servers/plots/)
 
 Extract numerical data from plot images for analysis and reproduction.
-
-## Getting an API Key
-
-1. Fill the following [form](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform?usp=dialog) to request an Axiomatic_AI API key.
-2. Once received, add the API key to your MCP client configuration as described in the Configuration section below.
-
-## Configuration
-
-Add the following settings to your MCP client configuration file or environment variables.
-
-### API Key
-
-All Axiomatic MCP servers require an API:
-
-- `AXIOMATIC_API_KEY`: Your API key obtained after filling the request form.
-
-### Telemetry
-
-By default, we track tool usage to help us improve the services. You can optionally disable this feature:
-
-- Set `DISABLE_TELEMETRY: "true"` in your MCP client configuration.
-
-## Installation
-
-### System requirements
-
-- Python
-- [uv](https://docs.astral.sh/uv/getting-started/installation/)
-
-### Individual MCP server installation
-
-Installation instructions can be found for each specific server in their README.
-
-### Install all servers
-
-Copy the content of the [mcp-example.json](mcp-example.json) file into your AI client MCP server config json.
-
-### Setting up MCP Servers in AI Clients
-
-#### Claude Desktop
-
-1. Open Claude Desktop settings
-2. Navigate to Developer → Edit MCP config
-3. Add the server configuration(s) above
-4. Restart Claude Desktop
-
-#### Cursor
-
-1. Open Cursor settings (Cmd/Ctrl + ,)
-2. Search for "MCP"
-3. Add the server configuration(s) to the MCP settings
-4. Restart Cursor
-
-#### Other MCP Clients
-
-Refer to your client's documentation for MCP server configuration.
 
 ## Troubleshooting
 

--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -20,7 +20,11 @@ async def setup():
         await axiomatic_mcp.import_server(server.server, prefix=server.name)
 
 
-if __name__ == "__main__":
+def main():
+    """Main entry point for the all-in-one server."""
     asyncio.run(setup())
-
     axiomatic_mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Axiomatic MCP Servers - Modular MCP servers built with FastMCP."""
 
-__version__ = "1.0.0"
+__version__ = "0.1.3"
 
 import asyncio
 
@@ -11,7 +11,7 @@ from .servers import servers
 axiomatic_mcp = FastMCP(
     name="Axiomatic MCP",
     instructions="""This server provides various tools to help with physics and engineering workflows..""",
-    version="0.0.1",
+    version=__version__,
 )
 
 

--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -17,7 +17,7 @@ axiomatic_mcp = FastMCP(
 
 async def setup():
     for server in servers:
-        await axiomatic_mcp.import_server(server.server, prefix=server.name)
+        await axiomatic_mcp.import_server(server["server"], prefix=server["name"])
 
 
 def main():

--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -1,3 +1,26 @@
 """Axiomatic MCP Servers - Modular MCP servers built with FastMCP."""
 
 __version__ = "1.0.0"
+
+import asyncio
+
+from fastmcp import FastMCP
+
+from .servers import servers
+
+axiomatic_mcp = FastMCP(
+    name="Axiomatic MCP",
+    instructions="""This server provides various tools to help with physics and engineering workflows..""",
+    version="0.0.1",
+)
+
+
+async def setup():
+    for server in servers:
+        await axiomatic_mcp.import_server(server.server, prefix=server.name)
+
+
+if __name__ == "__main__":
+    asyncio.run(setup())
+
+    axiomatic_mcp.run(transport="stdio")

--- a/axiomatic_mcp/__main__.py
+++ b/axiomatic_mcp/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/axiomatic_mcp/servers/__init__.py
+++ b/axiomatic_mcp/servers/__init__.py
@@ -1,9 +1,30 @@
 """Domain-specific MCP servers."""
 
-from .pic.server import mcp as pic_mcp
+from typing import TypedDict
 
-servers = [
-    pic_mcp,
+from fastmcp import FastMCP
+
+from .annotations.server import mcp as annotations_mcp
+from .axmodelfitter.server import mcp as axmodelfitter_mcp
+from .documents.server import mcp as documents_mcp
+from .equations.server import mcp as equations_mcp
+from .pic.server import mcp as pic_mcp
+from .plots.server import mcp as plots_mcp
+
+
+class ServerConfig(TypedDict):
+    domain: str
+    name: str
+    server: FastMCP
+
+
+servers: list[ServerConfig] = [
+    ServerConfig(domain="pic", name="AxPhotonicsPreview", server=pic_mcp),
+    ServerConfig(domain="equations", name="AxEquationExplorer", server=equations_mcp),
+    ServerConfig(domain="documents", name="AxDocumentParser", server=documents_mcp),
+    ServerConfig(domain="annotations", name="AxDocumentAnnotator", server=annotations_mcp),
+    ServerConfig(domain="axmodelfitter", name="AxModelFitter", server=axmodelfitter_mcp),
+    ServerConfig(domain="plots", name="AxPlotToData", server=plots_mcp),
 ]
 
-__all__ = ["pic_mcp"]
+__all__ = ["ServerConfig", "servers"]

--- a/axiomatic_mcp/servers/__init__.py
+++ b/axiomatic_mcp/servers/__init__.py
@@ -9,7 +9,7 @@ from .axmodelfitter.server import mcp as axmodelfitter_mcp
 from .documents.server import mcp as documents_mcp
 from .equations.server import mcp as equations_mcp
 from .pic.server import mcp as pic_mcp
-from .plots.server import mcp as plots_mcp
+from .plots.server import plots as plots_mcp
 
 
 class ServerConfig(TypedDict):

--- a/axiomatic_mcp/servers/annotations/README.md
+++ b/axiomatic_mcp/servers/annotations/README.md
@@ -49,10 +49,7 @@ Extract all equations and their parameters from the technical document at /docum
 
 ### Getting an API Key
 
-First you will need to get an API key.
-
-1. Fill the following [form](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform?usp=dialog) to request an Axiomatic_AI API key.
-2. Once received, add the API key to your MCP client configuration as described in the Configuration section below.
+[![Static Badge](https://img.shields.io/badge/Get%20your%20API%20key-6EB700?style=flat)](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform)
 
 ### Cursor Installation
 

--- a/axiomatic_mcp/servers/axmodelfitter/README.md
+++ b/axiomatic_mcp/servers/axmodelfitter/README.md
@@ -8,10 +8,7 @@ AxModelFitter enables AI assistants to fit mathematical models against experimen
 
 ### Getting an API Key
 
-First you will need to get an API key.
-
-1. Fill the following [form](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform?usp=dialog) to request an Axiomatic_AI API key.
-2. Once received, add the API key to your MCP client configuration as described in the Configuration section below.
+[![Static Badge](https://img.shields.io/badge/Get%20your%20API%20key-6EB700?style=flat)](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform)
 
 ### Installation (via PyPI)
 

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -1,3 +1,5 @@
+# ruff: noqa
+
 """AxModelFitter server using the Axiomatic API.
 
 This server provides tools for fitting custom mathematical models to experimental data
@@ -487,7 +489,7 @@ async def fit_model(
     parameters: Annotated[list, "Initial parameter guesses: [{'name': 'a', 'value': {'magnitude': 2.0, 'unit': 'dimensionless'}}]"],
     bounds: Annotated[
         list,
-        "ALL parameter/input/output bounds: [{'name': 'a', 'lower': {'magnitude': 0, 'unit': 'dimensionless'}, 'upper': {'magnitude': 10, 'unit': 'dimensionless'}}]",  # noqa E501
+        "ALL parameter/input/output bounds: [{'name': 'a', 'lower': {'magnitude': 0, 'unit': 'dimensionless'}, 'upper': {'magnitude': 10, 'unit': 'dimensionless'}}]",
     ],
     # File-based data input (REQUIRED)
     data_file: Annotated[str, "Path to data file (CSV, Excel, JSON, Parquet). All data must be provided via file."],
@@ -627,7 +629,7 @@ Use `get_fitting_examples` to see working examples.
 
 @mcp.prompt(
     name="get_workflow_prompt",
-    description="Step-by-step guide for model fitting with the AxModelFitter. Shows complete workflow from model definition to optimization execution.",  # noqa
+    description="Step-by-step guide for model fitting with the AxModelFitter. Shows complete workflow from model definition to optimization execution.",
 )
 def get_workflow_prompt() -> str:
     """Generate a generic optimization workflow guide."""

--- a/axiomatic_mcp/servers/documents/README.md
+++ b/axiomatic_mcp/servers/documents/README.md
@@ -44,10 +44,7 @@ Write the markdown to a file
 
 ### Getting an API Key
 
-First you will need to get an API key.
-
-1. Fill the following [form](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform?usp=dialog) to request an Axiomatic_AI API key.
-2. Once received, add the API key to your MCP client configuration as described in the Configuration section below.
+[![Static Badge](https://img.shields.io/badge/Get%20your%20API%20key-6EB700?style=flat)](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform)
 
 ### Cursor Installation
 

--- a/axiomatic_mcp/servers/equations/README.md
+++ b/axiomatic_mcp/servers/equations/README.md
@@ -51,10 +51,7 @@ Please, visit `/examples/equations/derive_H_energy_states/` and `/examples/equat
 
 ### Getting an API Key
 
-First you will need to get an API key.
-
-1. Fill the following [form](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform?usp=dialog) to request an Axiomatic_AI API key.
-2. Once received, add the API key to your MCP client configuration as described in the Configuration section below.
+[![Static Badge](https://img.shields.io/badge/Get%20your%20API%20key-6EB700?style=flat)](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform)
 
 ### Cursor Installation
 

--- a/axiomatic_mcp/servers/pic/README.md
+++ b/axiomatic_mcp/servers/pic/README.md
@@ -99,10 +99,7 @@ Gets detailed information about a specific PDK, including its available cross-se
 
 ### Getting an API Key
 
-First you will need to get an API key.
-
-1. Fill the following [form](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform?usp=dialog) to request an Axiomatic_AI API key.
-2. Once received, add the API key to your MCP client configuration as described in the Configuration section below.
+[![Static Badge](https://img.shields.io/badge/Get%20your%20API%20key-6EB700?style=flat)](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform)
 
 ### System requirements
 

--- a/axiomatic_mcp/servers/plots/README.md
+++ b/axiomatic_mcp/servers/plots/README.md
@@ -47,10 +47,7 @@ Extract data points from the plot at /path/to/experiment_results.png
 
 ### Getting an API Key
 
-First you will need to get an API key.
-
-1. Fill the following [form](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform?usp=dialog) to request an Axiomatic_AI API key.
-2. Once received, add the API key to your MCP client configuration as described in the Configuration section below.
+[![Static Badge](https://img.shields.io/badge/Get%20your%20API%20key-6EB700?style=flat)](https://docs.google.com/forms/d/e/1FAIpQLSfScbqRpgx3ZzkCmfVjKs8YogWDshOZW9p-LVXrWzIXjcHKrQ/viewform)
 
 ### Cursor Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiomatic-mcp"
-version = "0.1.2"
+version = "0.1.3"
 description = "Modular MCP servers for Axiomatic_AI"
 authors = [{name = "Axiomatic Team", email = "developers@axiomatic-ai.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ axiomatic-plots = "axiomatic_mcp.servers.plots:main"
 axiomatic-equations = "axiomatic_mcp.servers.equations:main"
 axiomatic-axmodelfitter = "axiomatic_mcp.servers.axmodelfitter:main"
 axiomatic-annotations = "axiomatic_mcp.servers.annotations:main"
+axiomatic-mcp = "axiomatic_mcp"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ axiomatic-plots = "axiomatic_mcp.servers.plots:main"
 axiomatic-equations = "axiomatic_mcp.servers.equations:main"
 axiomatic-axmodelfitter = "axiomatic_mcp.servers.axmodelfitter:main"
 axiomatic-annotations = "axiomatic_mcp.servers.annotations:main"
-axiomatic-mcp = "axiomatic_mcp"
+all = "axiomatic_mcp"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ axiomatic-plots = "axiomatic_mcp.servers.plots:main"
 axiomatic-equations = "axiomatic_mcp.servers.equations:main"
 axiomatic-axmodelfitter = "axiomatic_mcp.servers.axmodelfitter:main"
 axiomatic-annotations = "axiomatic_mcp.servers.annotations:main"
-all = "axiomatic_mcp"
+all = "axiomatic_mcp:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -109,7 +109,7 @@ wheels = [
 
 [[package]]
 name = "axiomatic-mcp"
-version = "0.0.10"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "cspdk" },
@@ -144,36 +144,62 @@ dev = [
 lean = [
     { name = "leanclient" },
 ]
+pic = [
+    { name = "cspdk" },
+    { name = "gdsfactory" },
+    { name = "iklayout" },
+    { name = "ipympl" },
+    { name = "kfactory" },
+    { name = "klayout" },
+    { name = "klujax" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "plotly" },
+    { name = "sax" },
+    { name = "scikit-learn" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "cspdk", specifier = ">=1.0.1" },
+    { name = "cspdk", marker = "extra == 'pic'", specifier = ">=1.0.1" },
     { name = "debugpy", specifier = ">=1.8.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "gdsfactory", specifier = ">=9.7.0" },
+    { name = "gdsfactory", marker = "extra == 'pic'", specifier = ">=9.7.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "iklayout", specifier = ">=0.0.8" },
+    { name = "iklayout", marker = "extra == 'pic'", specifier = ">=0.0.8" },
     { name = "ipympl", specifier = ">=0.9.7" },
+    { name = "ipympl", marker = "extra == 'pic'", specifier = ">=0.9.7" },
     { name = "kfactory", specifier = ">=1.7.3" },
+    { name = "kfactory", marker = "extra == 'pic'", specifier = ">=1.7.3" },
     { name = "klayout", specifier = ">=0.30.2" },
+    { name = "klayout", marker = "extra == 'pic'", specifier = ">=0.30.2" },
     { name = "klujax", specifier = ">=0.4.3" },
+    { name = "klujax", marker = "extra == 'pic'", specifier = ">=0.4.3" },
     { name = "leanclient", marker = "extra == 'lean'", specifier = "==0.1.14" },
     { name = "moesifasgi", specifier = ">=1.1.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "nbformat", specifier = ">=5.10.4" },
     { name = "numpy", specifier = ">=1.21.0" },
+    { name = "numpy", marker = "extra == 'pic'", specifier = ">=1.21.0" },
     { name = "pandas", specifier = ">=1.3.0" },
+    { name = "pandas", marker = "extra == 'pic'", specifier = ">=1.3.0" },
     { name = "plotly", specifier = ">=6.1.2" },
+    { name = "plotly", marker = "extra == 'pic'", specifier = ">=6.1.2" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "sax", specifier = ">=0.14.5" },
+    { name = "sax", marker = "extra == 'pic'", specifier = ">=0.14.5" },
     { name = "scikit-learn", specifier = ">=1.0.0" },
+    { name = "scikit-learn", marker = "extra == 'pic'", specifier = ">=1.0.0" },
 ]
-provides-extras = ["dev", "lean"]
+provides-extras = ["dev", "lean", "pic"]
 
 [[package]]
 name = "black"


### PR DESCRIPTION
Addresses https://github.com/Axiomatic-AI/ax-mcp/issues/1

## Summary
- Added quickstart guide to README with clear installation steps
- Fixed server initialization to properly run as MCP server
- Added `make run` and `make inspect` commands for easier testing
- Updated version to 0.1.3

## Changes
- Enhanced README with comprehensive quickstart section
- Added `__main__.py` module for direct execution
- Fixed server initialization in `__init__.py` files
- Added Makefile commands for running and inspecting the MCP server
- Updated development documentation

## Test Plan
1. Run `make install` to install the package
2. Test the server with MCP inspector:
   ```bash
   make inspect
   ```
   This will launch the MCP inspector UI where you can connect and test tools


5. Verify the quickstart instructions work for new users

🤖 Generated with [Claude Code](https://claude.ai/code)