### PR TITLE
Feat/improve api error reporting

### DIFF
--- a/axiomatic_mcp/shared/middleware/moesif_mcp_middleware.py
+++ b/axiomatic_mcp/shared/middleware/moesif_mcp_middleware.py
@@ -85,7 +85,7 @@ class MoesifMcpMiddleware(StructuredLoggingMiddleware):
         except Exception as e:
             tool_call_success = False
             response_body = {"error": str(e)}
-            raise Exception from e
+            raise
         finally:
             end_time = datetime.now(timezone.utc)
             duration_ms = int((end_time - start_time).total_seconds() * 1000)


### PR DESCRIPTION
added a helper method in api client to extract information from the request response after a failure. tihs way now the fastapi response message is apparent to the llm client

also re-raised the sam exception in the moesif middleware to prevent losing the original exception