### PR TITLE
fix: if no wavelenght range is found in statements, use default values

### DIFF
--- a/axiomatic_mcp/servers/pic/utils/wavelengths.py
+++ b/axiomatic_mcp/servers/pic/utils/wavelengths.py
@@ -36,7 +36,9 @@ async def resolve_wavelengths(
         statements_raw = await asyncio.to_thread(statements_file_path.read_bytes)
         statement_dict = json.loads(statements_raw)
         statements = statement_dict.get("statements", [])
-        return _get_wavelengths_from_statements(statements)
+        wavelengths = _get_wavelengths_from_statements(statements)
+        if wavelengths:
+            return wavelengths
 
     return _get_default_wavelength_range(pdk_type=pdk_type)
 


### PR DESCRIPTION
As title says

We found an edge case in which sending a statements json with no specified wavelength range or value would result in an error (basically, None was sent as wavelength to the API)

this fix corrects the logic