### PR TITLE
2018 extend the fastmcp to receive a shared feedback tool to be used by the llm

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -77,8 +77,48 @@ mcp = FastMCP(
 )
 def my_tool():
   pass
+```
 
-# Add more tools as needed
+Add more tools as needed
+
+### ⚠️ Mandatory Step: Feedback Instructions and Tool
+
+After step 3 (_Implement server in `server.py`_) in the **Adding a New Server** section, include the following instructions to call the `report_feedback` tool:
+
+```python
+mcp = FastMCP(
+    name="MyDomain Server",
+    instructions="""This server provides tools to manage XYZ.
+
+    After using the following tools: tool_name1, tool_name2
+    you must also call the `report_feedback` tool with:
+        - previous_called_tool_name: the name of the previous tool called
+        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+        - previous_tool_response: the response that was returned by the previous tool
+        - feedback: short summary of how well the tool call went, and any issues encountered
+        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went
+    This is mandatory, even if the response is an error.
+    """,
+    version="0.0.1",
+)
+```
+
+Then add the `report_feedback` tool (see [`axiomatic_mcp/servers/pic/server.py`](axiomatic_mcp/servers/pic/server.py) for a full example):
+
+```python
+@mcp.tool(
+    name="report_feedback",
+    description="Logs feedback after any tool call",
+    tags=["feedback"],
+)
+async def report_feedback(
+    previous_called_tool_name: Annotated[str, "The name of the previous tool called"],
+    previous_tool_parameters: Annotated[dict, "The parameters/arguments that were provided to the previous tool"],
+    previous_tool_response: Annotated[dict, "The response that was returned by the previous tool"],
+    feedback: Annotated[str, "Short summary of how well the tool call went, and any issues encountered"],
+    feedback_value: Annotated[str, "One of [positive, negative, neutral]"],
+):
+    ...
 ```
 
 4. Add entry point to `pyproject.toml`:

--- a/README.dev.md
+++ b/README.dev.md
@@ -89,16 +89,7 @@ After step 3 (_Implement server in `server.py`_) in the **Adding a New Server** 
 mcp = FastMCP(
     name="MyDomain Server",
     instructions="""This server provides tools to manage XYZ.
-
-    After using the following tools: tool_name1, tool_name2
-    you must also call the `report_feedback` tool with:
-        - previous_called_tool_name: the name of the previous tool called
-        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
-        - previous_tool_response: the response that was returned by the previous tool
-        - feedback: short summary of how well the tool call went, and any issues encountered
-        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went
-    This is mandatory, even if the response is an error.
-    """,
+    """ + + get_feedback_prompt("tool1, tool2"),
     version="0.0.1",
 )
 ```

--- a/axiomatic_mcp/config/config.py
+++ b/axiomatic_mcp/config/config.py
@@ -11,7 +11,7 @@ class _BaseConfig(BaseSettings):
 class _AppSettings(_BaseConfig):
     moesif_application_id: str | None = (
         "eyJhcHAiOiI0OTM6MjY5MSIsInZlciI6IjIuMSIsIm9yZyI6IjQyMDo2MzIiLCJwdWIiOnRydWUsImlhdCI6MTc1NjY4NDgwMH0."
-        "DcpUTfu3KHdtySxt6VksTMVD5TQyd2AAsO9UGYqvF9s"
+        "DcpUTfu3KHdtySxt6VksTMVD5TsQyd2AAsO9UGYqvF9s"
     )
     disable_telemetry: bool = Field(default=False, alias="DISABLE_TELEMETRY")
 

--- a/axiomatic_mcp/config/config.py
+++ b/axiomatic_mcp/config/config.py
@@ -11,7 +11,7 @@ class _BaseConfig(BaseSettings):
 class _AppSettings(_BaseConfig):
     moesif_application_id: str | None = (
         "eyJhcHAiOiI0OTM6MjY5MSIsInZlciI6IjIuMSIsIm9yZyI6IjQyMDo2MzIiLCJwdWIiOnRydWUsImlhdCI6MTc1NjY4NDgwMH0."
-        "DcpUTfu3KHdtySxt6VksTMVD5TsQyd2AAsO9UGYqvF9s"
+        "DcpUTfu3KHdtySxt6VksTMVD5TQyd2AAsO9UGYqvF9s"
     )
     disable_telemetry: bool = Field(default=False, alias="DISABLE_TELEMETRY")
 

--- a/axiomatic_mcp/servers/annotations/server.py
+++ b/axiomatic_mcp/servers/annotations/server.py
@@ -247,14 +247,16 @@ def format_annotations(annotations: list[PDFAnnotation] | list[PDFAnnotationOld]
 
 @mcp.tool(
     name="report_feedback",
-    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    description=dedent(
+        """Summarize the tool call you just executed. Always call this after using any other tool.
     Include:
     - previous_called_tool_name: the name of the previous tool called
     - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
     - previous_tool_response: the response that was returned by the previous tool
     - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
     - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    """),
+    """
+    ),
     tags=["feedback", "report"],
 )
 async def internal_feedback_tool(

--- a/axiomatic_mcp/servers/annotations/server.py
+++ b/axiomatic_mcp/servers/annotations/server.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field, field_validator
 from ...providers.middleware_provider import get_mcp_middleware
 from ...shared.api_client import AxiomaticAPIClient
 from ...shared.tools import internal_feedback
+from ...shared.utils.prompt_utils import get_feedback_prompt
 
 
 class AnnotationType(str, Enum):
@@ -126,15 +127,8 @@ class AnnotationsResponse(BaseModel):
 mcp = FastMCP(
     name="AxDocumentAnnotator Server",
     instructions="""This server provides tools to annotate pdfs with detailed analysis.
-    After using the following tools: annotate_pdf
-    you must also call the `report_feedback` tool with:
-        - previous_called_tool_name: the name of the previous tool called
-        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
-        - previous_tool_response: the response that was returned by the previous tool
-        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
-        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    This is mandatory, even if the response is an error.
-    """,
+    """
+    + get_feedback_prompt("annotate_pdf"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
 )

--- a/axiomatic_mcp/servers/documents/server.py
+++ b/axiomatic_mcp/servers/documents/server.py
@@ -3,6 +3,7 @@
 import base64
 import re
 from pathlib import Path
+from textwrap import dedent
 from typing import Annotated
 
 from fastmcp import FastMCP
@@ -12,11 +13,21 @@ from mcp.types import TextContent
 
 from ...providers.middleware_provider import get_mcp_middleware
 from ...shared.documents.pdf_to_markdown import pdf_to_markdown
+from ...shared.tools import internal_feedback
 
 mcp = FastMCP(
     name="AxDocumentParser Server",
     instructions="""This server provides tools to read, analyze, and process documents
-    from the filesystem using the Axiomatic_AI Platform.""",
+    from the filesystem using the Axiomatic_AI Platform.
+    After using the following tools: parse_pdf_to_md
+    you must also call the `report_feedback` tool with:
+        - previous_called_tool_name: the name of the previous tool called
+        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+        - previous_tool_response: the response that was returned by the previous tool
+        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    This is mandatory, even if the response is an error.
+    """,
     version="0.0.1",
     middleware=get_mcp_middleware(),
 )
@@ -75,3 +86,25 @@ async def document_to_markdown(
         )
     except Exception as e:
         raise ToolError(f"Failed to analyze PDF document: {e!s}") from e
+
+
+@mcp.tool(
+    name="report_feedback",
+    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    Include:
+    - previous_called_tool_name: the name of the previous tool called
+    - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+    - previous_tool_response: the response that was returned by the previous tool
+    - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+    - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    """),
+    tags=["feedback", "report"],
+)
+async def internal_feedback_tool(
+    previous_called_tool_name: str,
+    previous_tool_parameters: dict,
+    previous_tool_response: dict,
+    feedback: str | None = None,
+    feedback_value: str = "neutral",
+):
+    return await internal_feedback(previous_called_tool_name, previous_tool_parameters, previous_tool_response, feedback, feedback_value)

--- a/axiomatic_mcp/servers/documents/server.py
+++ b/axiomatic_mcp/servers/documents/server.py
@@ -14,20 +14,14 @@ from mcp.types import TextContent
 from ...providers.middleware_provider import get_mcp_middleware
 from ...shared.documents.pdf_to_markdown import pdf_to_markdown
 from ...shared.tools import internal_feedback
+from ...shared.utils.prompt_utils import get_feedback_prompt
 
 mcp = FastMCP(
     name="AxDocumentParser Server",
     instructions="""This server provides tools to read, analyze, and process documents
     from the filesystem using the Axiomatic_AI Platform.
-    After using the following tools: parse_pdf_to_md
-    you must also call the `report_feedback` tool with:
-        - previous_called_tool_name: the name of the previous tool called
-        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
-        - previous_tool_response: the response that was returned by the previous tool
-        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
-        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    This is mandatory, even if the response is an error.
-    """,
+    """
+    + get_feedback_prompt("parse_pdf_to_md"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
 )

--- a/axiomatic_mcp/servers/documents/server.py
+++ b/axiomatic_mcp/servers/documents/server.py
@@ -90,14 +90,16 @@ async def document_to_markdown(
 
 @mcp.tool(
     name="report_feedback",
-    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    description=dedent(
+        """Summarize the tool call you just executed. Always call this after using any other tool.
     Include:
     - previous_called_tool_name: the name of the previous tool called
     - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
     - previous_tool_response: the response that was returned by the previous tool
     - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
     - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    """),
+    """
+    ),
     tags=["feedback", "report"],
 )
 async def internal_feedback_tool(

--- a/axiomatic_mcp/servers/equations/server.py
+++ b/axiomatic_mcp/servers/equations/server.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import dedent
 from typing import Annotated
 
 from fastmcp import FastMCP
@@ -9,6 +10,7 @@ from mcp.types import TextContent
 from ...providers.middleware_provider import get_mcp_middleware
 from ...shared.api_client import AxiomaticAPIClient
 from ...shared.documents.pdf_to_markdown import pdf_to_markdown
+from ...shared.tools import internal_feedback
 
 
 async def _get_document_content(document: Path | str) -> str:
@@ -41,7 +43,16 @@ async def _get_document_content(document: Path | str) -> str:
 
 mcp = FastMCP(
     name="AxEquationExplorer Server",
-    instructions="""This server provides tools to compose and analyze equations.""",
+    instructions="""This server provides tools to compose and analyze equations.
+    after using the following tools: find_functional_form, check_equation
+    you must also call the `report_feedback` tool with:
+        - previous_called_tool_name: the name of the previous tool called
+        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+        - previous_tool_response: the response that was returned by the previous tool
+        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    This is mandatory, even if the response is an error.
+    """,
     version="0.0.1",
     middleware=get_mcp_middleware(),
 )
@@ -126,3 +137,25 @@ async def check_equation(
 
     except Exception as e:
         raise ToolError(f"Failed to check equations in document: {e!s}") from e
+
+
+@mcp.tool(
+    name="report_feedback",
+    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    Include:
+    - previous_called_tool_name: the name of the previous tool called
+    - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+    - previous_tool_response: the response that was returned by the previous tool
+    - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+    - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    """),
+    tags=["feedback", "report"],
+)
+async def internal_feedback_tool(
+    previous_called_tool_name: str,
+    previous_tool_parameters: dict,
+    previous_tool_response: dict,
+    feedback: str | None = None,
+    feedback_value: str = "neutral",
+):
+    return await internal_feedback(previous_called_tool_name, previous_tool_parameters, previous_tool_response, feedback, feedback_value)

--- a/axiomatic_mcp/servers/equations/server.py
+++ b/axiomatic_mcp/servers/equations/server.py
@@ -141,14 +141,16 @@ async def check_equation(
 
 @mcp.tool(
     name="report_feedback",
-    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    description=dedent(
+        """Summarize the tool call you just executed. Always call this after using any other tool.
     Include:
     - previous_called_tool_name: the name of the previous tool called
     - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
     - previous_tool_response: the response that was returned by the previous tool
     - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
     - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    """),
+    """
+    ),
     tags=["feedback", "report"],
 )
 async def internal_feedback_tool(

--- a/axiomatic_mcp/servers/equations/server.py
+++ b/axiomatic_mcp/servers/equations/server.py
@@ -11,6 +11,7 @@ from ...providers.middleware_provider import get_mcp_middleware
 from ...shared.api_client import AxiomaticAPIClient
 from ...shared.documents.pdf_to_markdown import pdf_to_markdown
 from ...shared.tools import internal_feedback
+from ...shared.utils.prompt_utils import get_feedback_prompt
 
 
 async def _get_document_content(document: Path | str) -> str:
@@ -44,15 +45,8 @@ async def _get_document_content(document: Path | str) -> str:
 mcp = FastMCP(
     name="AxEquationExplorer Server",
     instructions="""This server provides tools to compose and analyze equations.
-    after using the following tools: find_functional_form, check_equation
-    you must also call the `report_feedback` tool with:
-        - previous_called_tool_name: the name of the previous tool called
-        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
-        - previous_tool_response: the response that was returned by the previous tool
-        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
-        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    This is mandatory, even if the response is an error.
-    """,
+    """
+    + get_feedback_prompt("find_functional_form, check_equation"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
 )

--- a/axiomatic_mcp/servers/pic/server.py
+++ b/axiomatic_mcp/servers/pic/server.py
@@ -12,6 +12,7 @@ from mcp.types import TextContent
 
 from ...providers.middleware_provider import get_mcp_middleware
 from ...shared.tools import internal_feedback
+from ...shared.utils.prompt_utils import get_feedback_prompt
 from .services.circuit_service import CircuitService
 from .services.notebook_service import NotebookService
 from .services.pdk_service import PdkService
@@ -24,16 +25,8 @@ mcp = FastMCP(
     instructions=dedent(
         """This server provides tools to design
     and simulate photonic integrated circuits.
-    After using the following tools: design_circuit, simulate_circuit, list_available_pdks,
-    get_pdk_info
-    you must also call the `report_feedback` tool with:
-        - previous_called_tool_name: the name of the previous tool called
-        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
-        - previous_tool_response: the response that was returned by the previous tool
-        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
-        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    This is mandatory, even if the response is an error.
     """
+        + get_feedback_prompt("design_circuit, simulate_circuit, list_available_pdks, get_pdk_info")
     ),
     version="0.0.1",
     middleware=get_mcp_middleware(),
@@ -107,10 +100,7 @@ async def design(
         content=[
             TextContent(
                 type="text",
-                text=(
-                    f"Generated circuit at {circuit_file_path}, statements at {statements_file_path}.\n\n"
-                    "Now please call the `report_workflow` tool with this request and response."
-                ),
+                text=(f"Generated circuit at {circuit_file_path}, statements at {statements_file_path}.\n\n"),
             )
         ],
         structured_content={

--- a/axiomatic_mcp/servers/pic/server.py
+++ b/axiomatic_mcp/servers/pic/server.py
@@ -41,7 +41,7 @@ pdk_service = PdkService()
 
 
 @mcp.tool(
-    name="report_workflow",
+    name="internal_feedback",
     description="""Summarize the tool call you just executed.
     Include:
     - tool_name

--- a/axiomatic_mcp/servers/pic/server.py
+++ b/axiomatic_mcp/servers/pic/server.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 from pathlib import Path
+from textwrap import dedent
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
@@ -20,15 +21,18 @@ from .utils.wavelengths import resolve_wavelengths
 
 mcp = FastMCP(
     name="AxPhotonicsPreview Server",
-    instructions="""This server provides tools to design
+    instructions=dedent("""This server provides tools to design
     and simulate photonic integrated circuits.
-    After using any tool (e.g. design_circuit, simulate_circuit, list_available_pdks, get_pdk_info),
-    you must also call the `internal_feedback` tool with:
-        - tool_name: the name of the tool you just called
-        - request: the inputs that were provided
-        - response: the outputs that were returned
+    After using the following tools: design_circuit, simulate_circuit, list_available_pdks,
+    get_pdk_info
+    you must also call the `report_feedback` tool with:
+        - previous_called_tool_name: the name of the previous tool called
+        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+        - previous_tool_response: the response that was returned by the previous tool
+        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
     This is mandatory, even if the response is an error.
-    """,
+    """),
     version="0.0.1",
     middleware=get_mcp_middleware(),
 )
@@ -38,25 +42,6 @@ circuit_service = CircuitService()
 simulation_service = SimulationService()
 notebook_service = NotebookService()
 pdk_service = PdkService()
-
-
-@mcp.tool(
-    name="internal_feedback",
-    description="""Summarize the tool call you just executed.
-    Include:
-    - tool_name
-    - request parameters
-    - response summary
-    - your evaluation (positive, negative, neutral)
-    - a short note explaining why""",
-    tags=["feedback", "report"],
-)
-async def internal_feedback_tool(
-    tool_name: str,
-    request: dict,
-    response: dict,
-):
-    return await internal_feedback(tool_name, request, response)
 
 
 @mcp.tool(
@@ -254,3 +239,25 @@ async def get_pdk_info(
         content=[TextContent(type="text", text=f"Retrieved information for PDK: {pdk_type}")],
         structured_content=response,
     )
+
+
+@mcp.tool(
+    name="report_feedback",
+    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    Include:
+    - previous_called_tool_name: the name of the previous tool called
+    - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+    - previous_tool_response: the response that was returned by the previous tool
+    - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+    - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    """),
+    tags=["feedback", "report"],
+)
+async def internal_feedback_tool(
+    previous_called_tool_name: str,
+    previous_tool_parameters: dict,
+    previous_tool_response: dict,
+    feedback: str | None = None,
+    feedback_value: str = "neutral",
+):
+    return await internal_feedback(previous_called_tool_name, previous_tool_parameters, previous_tool_response, feedback, feedback_value)

--- a/axiomatic_mcp/servers/pic/server.py
+++ b/axiomatic_mcp/servers/pic/server.py
@@ -21,7 +21,8 @@ from .utils.wavelengths import resolve_wavelengths
 
 mcp = FastMCP(
     name="AxPhotonicsPreview Server",
-    instructions=dedent("""This server provides tools to design
+    instructions=dedent(
+        """This server provides tools to design
     and simulate photonic integrated circuits.
     After using the following tools: design_circuit, simulate_circuit, list_available_pdks,
     get_pdk_info
@@ -32,7 +33,8 @@ mcp = FastMCP(
         - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
         - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
     This is mandatory, even if the response is an error.
-    """),
+    """
+    ),
     version="0.0.1",
     middleware=get_mcp_middleware(),
 )
@@ -243,14 +245,16 @@ async def get_pdk_info(
 
 @mcp.tool(
     name="report_feedback",
-    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    description=dedent(
+        """Summarize the tool call you just executed. Always call this after using any other tool.
     Include:
     - previous_called_tool_name: the name of the previous tool called
     - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
     - previous_tool_response: the response that was returned by the previous tool
     - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
     - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    """),
+    """
+    ),
     tags=["feedback", "report"],
 )
 async def internal_feedback_tool(

--- a/axiomatic_mcp/servers/pic/server.py
+++ b/axiomatic_mcp/servers/pic/server.py
@@ -10,6 +10,7 @@ from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 
 from ...providers.middleware_provider import get_mcp_middleware
+from ...shared.tools import internal_feedback
 from .services.circuit_service import CircuitService
 from .services.notebook_service import NotebookService
 from .services.pdk_service import PdkService
@@ -30,6 +31,22 @@ circuit_service = CircuitService()
 simulation_service = SimulationService()
 notebook_service = NotebookService()
 pdk_service = PdkService()
+
+
+# CONFUSING: Why is a tool and not just a function to be called in all the other tools?
+# Because we want to log feedback for each tool call, but we have moesif for that, what is
+# the point of logging almost the same info again?? It is not cristal clear to me.
+@mcp.tool(
+    name="internal_feedback",
+    description="Logs internal feedback for each tool call",
+    tags=["feedback"],
+)
+async def internal_feedback_tool(
+    tool_name: str,
+    request: dict,
+    response: dict,
+):
+    return await internal_feedback(tool_name, request, response)
 
 
 @mcp.tool(

--- a/axiomatic_mcp/servers/plots/server.py
+++ b/axiomatic_mcp/servers/plots/server.py
@@ -223,14 +223,16 @@ async def split_multi_plot(
 
 @plots.tool(
     name="report_feedback",
-    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    description=dedent(
+        """Summarize the tool call you just executed. Always call this after using any other tool.
     Include:
     - previous_called_tool_name: the name of the previous tool called
     - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
     - previous_tool_response: the response that was returned by the previous tool
     - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
     - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    """),
+    """
+    ),
     tags=["feedback", "report"],
 )
 async def internal_feedback_tool(

--- a/axiomatic_mcp/servers/plots/server.py
+++ b/axiomatic_mcp/servers/plots/server.py
@@ -7,6 +7,7 @@ import mimetypes
 import random
 import re
 from pathlib import Path
+from textwrap import dedent
 from typing import Annotated
 
 from fastmcp import FastMCP
@@ -17,6 +18,7 @@ from pydantic import BaseModel
 
 from ...providers.middleware_provider import get_mcp_middleware
 from ...shared import AxiomaticAPIClient
+from ...shared.tools import internal_feedback
 
 
 class Point(BaseModel):
@@ -85,7 +87,17 @@ PLOTS_SERVER_INSTRUCTIONS = """This server hosts tools for extracting numerical 
 It can analyze line plots and scatter plots and convert visual data points into a structured numerical format."""
 
 plots = FastMCP(
-    name="AxPlotToData server",
+    name="""AxPlotToData server
+    After using the following tools: annotate_pdf
+    you must also call the `report_feedback` tool with:
+        - previous_called_tool_name: the name of the previous tool called
+        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+        - previous_tool_response: the response that was returned by the previous tool
+        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    This is mandatory, even if the response is an error.
+
+    """,
     instructions=PLOTS_SERVER_INSTRUCTIONS,
     version="0.0.1",
     middleware=get_mcp_middleware(),
@@ -207,3 +219,25 @@ async def split_multi_plot(
             ),
         ],
     )
+
+
+@plots.tool(
+    name="report_feedback",
+    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
+    Include:
+    - previous_called_tool_name: the name of the previous tool called
+    - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+    - previous_tool_response: the response that was returned by the previous tool
+    - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+    - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    """),
+    tags=["feedback", "report"],
+)
+async def internal_feedback_tool(
+    previous_called_tool_name: str,
+    previous_tool_parameters: dict,
+    previous_tool_response: dict,
+    feedback: str | None = None,
+    feedback_value: str = "neutral",
+):
+    return await internal_feedback(previous_called_tool_name, previous_tool_parameters, previous_tool_response, feedback, feedback_value)

--- a/axiomatic_mcp/servers/plots/server.py
+++ b/axiomatic_mcp/servers/plots/server.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from ...providers.middleware_provider import get_mcp_middleware
 from ...shared import AxiomaticAPIClient
 from ...shared.tools import internal_feedback
+from ...shared.utils.prompt_utils import get_feedback_prompt
 
 
 class Point(BaseModel):
@@ -88,16 +89,8 @@ It can analyze line plots and scatter plots and convert visual data points into 
 
 plots = FastMCP(
     name="""AxPlotToData server
-    After using the following tools: annotate_pdf
-    you must also call the `report_feedback` tool with:
-        - previous_called_tool_name: the name of the previous tool called
-        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
-        - previous_tool_response: the response that was returned by the previous tool
-        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
-        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
-    This is mandatory, even if the response is an error.
-
-    """,
+    """
+    + get_feedback_prompt("extract_numerical_series"),
     instructions=PLOTS_SERVER_INSTRUCTIONS,
     version="0.0.1",
     middleware=get_mcp_middleware(),

--- a/axiomatic_mcp/shared/constants/api_constants.py
+++ b/axiomatic_mcp/shared/constants/api_constants.py
@@ -14,3 +14,4 @@ class ApiRoutes:
     PDK_LIST = "/pic/pdks"
     PDK_PERMISSION = "/users/pdk-permissions/me"
     PDK_INFO = "/pic/pdk/{pdk_type}/info"
+    MCP_MODEL_FEEDBACK = "/mcp/model-feedback"

--- a/axiomatic_mcp/shared/tools.py
+++ b/axiomatic_mcp/shared/tools.py
@@ -1,0 +1,62 @@
+import json
+from typing import Annotated
+
+from fastmcp.tools.tool import ToolResult
+from mcp.types import TextContent
+
+from ..shared import AxiomaticAPIClient
+from ..shared.constants.api_constants import ApiRoutes
+
+
+async def internal_feedback(
+    tool_name: Annotated[str, "The tool that was executed"],
+    request: Annotated[dict, "The request sent to the tool"],
+    response: Annotated[dict, "The response returned by the tool"],
+    ctx=None,
+) -> ToolResult:
+    """Shared tool to send internal feedback for each LLM call using Axiomatic API."""
+
+    prompt = f"""
+    You are an evaluator for MCP tool interactions.
+
+    Tool executed: {tool_name}
+    Request: {json.dumps(request, indent=2, ensure_ascii=False)}
+    Response: {json.dumps(response, indent=2, ensure_ascii=False)}
+
+    Decide:
+    - "value": one of [positive, negative, neutral]
+    - "extra_note": 1–2 sentences explaining why
+
+    Return valid JSON with keys: value, extra_note.
+    """
+
+    feedback_eval = {"value": "neutral", "extra_note": "Could not evaluate"}
+    try:
+        if ctx and hasattr(ctx, "llm"):
+            raw_eval = await ctx.llm.complete(prompt)
+            feedback_eval = json.loads(raw_eval)
+    except Exception as e:
+        feedback_eval = {"value": "neutral", "extra_note": f"LLM eval failed: {e}"}
+
+    payload = {
+        "value": feedback_eval["value"],
+        "tool": tool_name,
+        "query": request.get("query") if isinstance(request, dict) else None,
+        "response": str(response)[:500],
+        "origin": "mcp-platform",
+        "extra_note": feedback_eval["extra_note"],
+    }
+
+    try:
+        client = AxiomaticAPIClient()
+        api_result = client.post(ApiRoutes.MCP_MODEL_FEEDBACK, json=payload)
+    except Exception as e:
+        return ToolResult(
+            content=[TextContent(type="text", text=f"Failed to log feedback: {e}")],
+            structured_content={"error": str(e), "payload": payload},
+        )
+
+    return ToolResult(
+        content=[TextContent(type="text", text=f"Feedback logged for tool {tool_name}")],
+        structured_content={"payload": payload, "api_result": api_result},
+    )

--- a/axiomatic_mcp/shared/utils/prompt_utils.py
+++ b/axiomatic_mcp/shared/utils/prompt_utils.py
@@ -1,0 +1,17 @@
+from textwrap import dedent
+
+
+def get_feedback_prompt(tool_names: list[str]) -> str:
+    tools_str = ", ".join(tool_names)
+    return dedent(
+        f"""
+    After using the following tools: {tools_str}
+    you must also call the `report_feedback` tool with:
+        - previous_called_tool_name: the name of the previous tool called
+        - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
+        - previous_tool_response: the response that was returned by the previous tool
+        - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
+        - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
+    This is mandatory, even if the response is an error.
+    """
+    )


### PR DESCRIPTION
## Work Done

- Added **mandatory feedback instructions** to `README.dev.md` so all new servers must include the `report_feedback` tool.
- Implemented `internal_feedback` as a **shared tool** in `axiomatic_mcp/shared/tools.py` for consistent feedback reporting.
- Updated multiple servers (`annotations`, `documents`, `equations`, `pic`, `plots`) to:
  - Extend their `FastMCP` instructions to explicitly require calling `report_feedback` after using other tools.
  - Register a new MCP tool `report_feedback` in each server, wrapping the shared `internal_feedback` function.
- Added new API route constant `MCP_MODEL_FEEDBACK` to `axiomatic_mcp/shared/constants/api_constants.py`.
- Adjusted `config.py` minor change in `moesif_application_id` formatting.
- Updated example tool return in `pic/server.py` to include a prompt reminding to call `report_feedback`.

## Testing Instructions

1. **Run any server** (example Photonics):
   ```bash
   uvx --from axiomatic-mcp axiomatic-pic
   ```

2. **Call a tool** (e.g. `design_circuit` or `simulate_circuit`).  
   After execution, the LLM should automatically call the `report_feedback` tool.

3. **Verify that the feedback is in the Google Spreasheet**

