### PR TITLE
add API Key to codex toml instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Create or edit the configuration file `~/.codex/config.toml` and add:
 [mcp_servers.axiomatic-mcp]
 command = "uvx"
 args = ["--from", "axiomatic-mcp", "all"]
+env = { AXIOMATIC_API_KEY = "your-api-key-here" }
 ```
 
 For more information, see the [Codex MCP documentation](https://github.com/openai/codex/blob/main/codex-rs/config.md#mcp_servers)


### PR DESCRIPTION
The API key must be added to the toml file to use the AX MCPs with Codex. Otherwise it won't work. Took me a while to figure that out, so I add it here in case someone needs to do this in the future.