### PR TITLE
fix: restore proper elicitation and feedback handling by rolling back FastMCP to 2.11.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,13 @@ install-dev:
 	@uv pip install -e ".[dev]"
 	@echo "✅ Dev environment ready!"
 
+install-pic:
+	@command -v uv >/dev/null 2>&1 || (echo "Installing uv..." && curl -LsSf https://astral.sh/uv/install.sh | sh)
+	@echo "Setting up development environment..."
+	@uv venv
+	@uv pip install -e ".[pic]"
+	@echo "✅ Pic Dev environment ready!"
+
 test:
 	@uv run pytest tests/ -v --tb=short || true
 

--- a/axiomatic_mcp/servers/pic/server.py
+++ b/axiomatic_mcp/servers/pic/server.py
@@ -62,6 +62,10 @@ async def design(
             pdk_types = pdk_service.list_pdks()
             flattened_pdks = flatten_pdks_response(pdk_types)
             pdk_type = await ctx.elicit(message="Please select a PDK to generate the circuit", response_type=flattened_pdks)
+
+            if not isinstance(pdk_type, str) or pdk_type not in flattened_pdks:
+                raise ValueError("Invalid PDK type")
+
         except Exception:
             pdk_type = "cspdk.si220.cband"
 
@@ -69,7 +73,6 @@ async def design(
         "query": query,
         "pdk_type": pdk_type,
     }
-
     if existing_code:
         refine_body["code"] = existing_code
 

--- a/axiomatic_mcp/servers/pic/services/optimization_service.py
+++ b/axiomatic_mcp/servers/pic/services/optimization_service.py
@@ -1,8 +1,8 @@
 from typing import Any
 
 from ....shared import AxiomaticAPIClient
+from ....shared.constants.api_constants import ApiRoutes
 from ....shared.models.singleton_base import SingletonBase
-from ...constants.api_constants import ApiRoutes
 
 
 class OptimizationService(SingletonBase):

--- a/axiomatic_mcp/shared/tools.py
+++ b/axiomatic_mcp/shared/tools.py
@@ -9,9 +9,9 @@ from ..shared.constants.api_constants import ApiRoutes
 
 
 async def internal_feedback(
-    previous_called_tool_name: Annotated[str, "The name of the previous tool called"],
-    previous_tool_parameters: Annotated[dict, "The parameters/arguments that were provided to the previous tool"],
-    previous_tool_response: Annotated[dict, "The response that was returned by the previous tool"],
+    previous_called_tool_name: Annotated[str | None, "The name of the previous tool called"],
+    previous_tool_parameters: Annotated[str | None, "The parameters/arguments that were provided to the previous tool"],
+    previous_tool_response: Annotated[str | None, "The response that was returned by the previous tool"],
     feedback: Annotated[str | None, "A short summary of how well the tool call went, and any issues encountered."] = None,
     feedback_value: Annotated[str, 'One of ["positive", "negative", "neutral"] indicating how well the tool call went.'] = "neutral",
 ) -> ToolResult:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 keywords = ["mcp", "axiomatic", "ai", "fastmcp"]
 urls = {Homepage = "https://github.com/Axiomatic-AI/ax-mcp", Issues = "https://github.com/Axiomatic-AI/ax-mcp/issues"}
 dependencies = [
-    "fastmcp>=0.1.0",
+    "fastmcp==2.11.3",
     "httpx>=0.25.0",
     "moesifasgi>=1.1.5",
     "numpy>=1.21.0",


### PR DESCRIPTION
### 1. Reinstall the virtual environment and rollback FastMCP
rm -rf .venv
make install && make install-dev && make install-pic

### 2. Launch the MCP server AxPhotonicsPreview

### 3. In Cursor, ask:
    → "Give me an MZI"
    → Verify that the elicitation works properly
    → Select a PDK
    → Ensure no 'invalid parameter type' errors appear in logs

### 4. Confirm that the feedback tool runs successfully and no serialization or validation errors occur