### PR TITLE
feat: add option to change API_URL from config

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -35,10 +35,10 @@ make install-dev
 
 ### Using staging or local environment
 
-In your MCP settings, change the `BASE_URL` parameter to point to the staging or local API (see configuration above):
+In your MCP settings, change the `API_URL` parameter to point to the staging or local API (see configuration above):
 
-- staging: `"BASE_URL": "https://api.staging.axiomatic-ai.com"`
-- local: `"BASE_URL": "http://localhost:8000"` (or your chosen port to run ax-stack)
+- staging: `"API_URL": "https://api.staging.axiomatic-ai.com"`
+- local: `"API_URL": "http://localhost:8000"` (or your chosen port to run ax-stack)
 
 ### Adding a New Server
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -26,11 +26,19 @@ make install-dev
     "args": ["-m", "axiomatic_mcp.servers.documents"],
     "env": {
       "AXIOMATIC_API_KEY": "your-api-key-here",
-      "DISABLE_TELEMETRY": "true" // optionally prevent sending logs to Moesif
+      "DISABLE_TELEMETRY": "true", // optionally prevent sending logs to Moesif
+      "API_URL": "https://api.staging.axiomatic-ai.com" // optionally point to staging/local environment
     }
   }
 }
 ```
+
+### Using staging or local environment
+
+In your MCP settings, change the `BASE_URL` parameter to point to the staging or local API (see configuration above):
+
+- staging: `"BASE_URL": "https://api.staging.axiomatic-ai.com"`
+- local: `"BASE_URL": "http://localhost:8000"` (or your chosen port to run ax-stack)
 
 ### Adding a New Server
 

--- a/axiomatic_mcp/shared/api_client.py
+++ b/axiomatic_mcp/shared/api_client.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import httpx
 
-API_URL = "https://api.axiomatic-ai.com"
+API_URL = os.getenv("API_URL", "https://api.axiomatic-ai.com")
 
 TIMEOUT = 1000
 


### PR DESCRIPTION
Adds a new configuration option to point the MCP server to another stage (staging or local). Updated `README.dev.md` with instructions. Defaults to prod API