### PR TITLE
fix: adding more robust handling of sigfigs in plot parser mcp

### DIFF
--- a/axiomatic_mcp/servers/plots/server.py
+++ b/axiomatic_mcp/servers/plots/server.py
@@ -80,15 +80,19 @@ def determine_sig_figs(response: dict) -> tuple[int, int]:
 
     x_max_sig_figs = 0
     for value in x_tick_values:
-        if value is not None:
+        try:
             sig_figs = count_significant_figures(float(value))
             x_max_sig_figs = max(x_max_sig_figs, sig_figs)
+        except (TypeError, ValueError):
+            continue
 
     y_max_sig_figs = 0
     for value in y_tick_values:
-        if value is not None:
+        try:
             sig_figs = count_significant_figures(float(value))
             y_max_sig_figs = max(y_max_sig_figs, sig_figs)
+        except (TypeError, ValueError):
+            continue
 
     x_sig_figs = max(MIN_SIG_FIGS, min(MAX_SIG_FIGS, x_max_sig_figs))
     y_sig_figs = max(MIN_SIG_FIGS, min(MAX_SIG_FIGS, y_max_sig_figs))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Dynamically determines x/y significant figures from axis ticks (clamped) and formats extracted points per-axis, removing the fixed sig_figs parameter.
> 
> - **plots/server.py**:
>   - **Sig figs handling**:
>     - Add `MIN_SIG_FIGS`/`MAX_SIG_FIGS`.
>     - New helpers: `count_significant_figures`, `determine_sig_figs` (analyzes `plot_info.x_axis_tick_values`/`y_axis_tick_values`, clamps to min/max).
>   - **Processing update** (`process_plot_parser_output`):
>     - Remove `sig_figs` arg; infer `x_sig_figs`/`y_sig_figs` from response.
>     - Format `x_value`/`y_value` using per-axis sig figs when sampling/condensing points.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f3246c99eadc48fde07c7d02697f742ee7ed787. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->