### PR TITLE
Updating the mcp to accept pdf without md conversion

### DIFF
--- a/axiomatic_mcp/servers/equations/server.py
+++ b/axiomatic_mcp/servers/equations/server.py
@@ -9,37 +9,8 @@ from mcp.types import TextContent
 from ...providers.middleware_provider import get_mcp_middleware
 from ...providers.toolset_provider import get_mcp_tools
 from ...shared.api_client import AxiomaticAPIClient
-from ...shared.documents.pdf_to_markdown import pdf_to_markdown
+from ...shared.utils.file_utils import get_file_type
 from ...shared.utils.prompt_utils import get_feedback_prompt
-
-
-async def _get_document_content(document: Path | str) -> str:
-    """Helper function to extract document content from either a file path or direct content."""
-    if isinstance(document, Path):
-        if not document.exists():
-            raise ValueError(f"File not found: {document}")
-
-        if document.suffix.lower() == ".pdf":
-            response = await pdf_to_markdown(document)
-            return response.markdown
-        elif document.suffix.lower() in [".md", ".txt"]:
-            with Path.open(document, encoding="utf-8") as f:
-                return f.read()
-        else:
-            raise ValueError(f"Unsupported file type: {document.suffix}. Supported types: .pdf, .md, .txt")
-
-    if len(document) < 500 and "\n" not in document:
-        potential_path = Path(document)
-        if potential_path.exists():
-            if potential_path.suffix.lower() == ".pdf":
-                response = await pdf_to_markdown(potential_path)
-                return response.markdown
-            elif potential_path.suffix.lower() in [".md", ".txt"]:
-                with Path.open(potential_path, encoding="utf-8") as f:
-                    return f.read()
-
-    return document
-
 
 mcp = FastMCP(
     name="AxEquationExplorer Server",
@@ -68,30 +39,42 @@ async def find_expression(
     interested in then use this tool and simply say: 'Express the energy in terms of
     velocity and position', or something like that. The tool will return the desired expression
     together with sympy code that explains how it was derived."""
-    try:
-        doc_content = await _get_document_content(document)
 
-        input_body = {"markdown": doc_content, "task": task}
-        response = AxiomaticAPIClient().post("/equations/derive/markdown", data=input_body)
-
-        if isinstance(document, Path) or (isinstance(document, str) and Path(document).exists()):
-            doc_path = Path(document)
-            file_path = doc_path.parent / f"{doc_path.stem}_code.py"
+    with AxiomaticAPIClient() as client:  # ← Fixed: Use context manager
+        if isinstance(document, Path) and get_file_type(str(document)) == "application/pdf":
+            files = {"pdf_file": (document.name, document.read_bytes(), "application/pdf")}
+            data = {"task": task}
+            response = client.post("/equations/derive", data=data, files=files)
+        elif isinstance(document, Path) and get_file_type(str(document)) in ["text/markdown", "text/plain", "text/html"]:
+            data = {"markdown": document.read_text(encoding="utf-8"), "task": task}
+            response = client.post("/equations/derive", data=data)
+        elif isinstance(document, str):
+            data = {"markdown": document, "task": task}
+            response = client.post("/equations/derive", data=data)
         else:
-            file_path = Path.cwd() / "expression_code.py"
+            raise ToolError(
+                f"Unsupported file type: {get_file_type(str(document)) if isinstance(document, Path) else 'string content'}. Supported types: pdf, markdown, plain text, html"
+            )
 
-        with Path.open(file_path, "w", encoding="utf-8") as f:
-            f.write(response.get("code", ""))
+    if isinstance(document, Path):
+        code_file_path = document.parent / f"{document.stem}_code.py"
+        explanation_file_path = document.parent / f"{document.stem}_explanation.md"
+    else:
+        code_file_path = Path.cwd() / "expression_code.py"
+        explanation_file_path = Path.cwd() / "expression_explanation.md"
 
-        return ToolResult(
-            content=[
-                TextContent(type="text", text=f"Explanation: {response.get('explanation', '')}"),
-                TextContent(type="text", text=f"Code: {response.get('code', '')}"),
-            ]
-        )
+    with Path.open(code_file_path, "w", encoding="utf-8") as f:
+        f.write(response.get("code", ""))
 
-    except Exception as e:
-        raise ToolError(f"Failed to derive the equation in the document: {e!s}") from e
+    with Path.open(explanation_file_path, "w", encoding="utf-8") as f:
+        f.write(response.get("explanation", ""))
+
+    return ToolResult(
+        content=[
+            TextContent(type="text", text=f"Explanation: {response.get('explanation', '')}"),
+            TextContent(type="text", text=f"Code: {response.get('code', '')}"),
+        ]
+    )
 
 
 @mcp.tool(
@@ -104,32 +87,45 @@ async def find_expression(
 )
 async def check_equation(
     document: Annotated[Path | str, "Either a file path to a PDF document or the document content as a string"],
-    task: Annotated[str, "The task to be done for equation checking (e.g., 'check if E=mc² is correct')"],
+    task: Annotated[str, "The task to be done for expression correctness checking"],
 ) -> ToolResult:
-    """Use this tool to validate equations or check for errors in mathematical expressions.
-    For example: 'Check if the equation F = ma is dimensionally consistent' or
-    'Verify the correctness of the Maxwell equations in the document'."""
-    try:
-        doc_content = await _get_document_content(document)
-        input_body = {"markdown": doc_content, "task": task}
-        # Note: Using the same endpoint for now, but this could be changed to a dedicated checking endpoint
-        response = AxiomaticAPIClient().post("/equations/check/markdown", data=input_body)
+    """If you have scientific text with equations, but you don't see the equation you're
+    interested in then use this tool and simply say: 'Express the energy in terms of
+    velocity and position', or something like that. The tool will return the desired expression
+    together with sympy code that explains how it was derived."""
 
-        if isinstance(document, Path) or (isinstance(document, str) and Path(document).exists()):
-            doc_path = Path(document)
-            file_path = doc_path.parent / f"{doc_path.stem}_code.py"
+    with AxiomaticAPIClient() as client:  # ← Fixed: Use context manager
+        if isinstance(document, Path) and get_file_type(str(document)) == "application/pdf":
+            files = {"pdf_file": (document.name, document.read_bytes(), "application/pdf")}
+            data = {"task": task}
+            response = client.post("/equations/check", data=data, files=files)
+        elif isinstance(document, Path) and get_file_type(str(document)) in ["text/markdown", "text/plain", "text/html"]:
+            data = {"markdown": document.read_text(encoding="utf-8"), "task": task}
+            response = client.post("/equations/check", data=data)
+        elif isinstance(document, str):
+            data = {"markdown": document, "task": task}
+            response = client.post("/equations/check", data=data)
         else:
-            file_path = Path.cwd() / "expression_code.py"
+            raise ToolError(
+                f"Unsupported file type: {get_file_type(str(document)) if isinstance(document, Path) else 'string content'}. Supported types: pdf, markdown, plain text, html"
+            )
 
-        with Path.open(file_path, "w", encoding="utf-8") as f:
-            f.write(response.get("code", ""))
+    if isinstance(document, Path):
+        code_file_path = document.parent / f"{document.stem}_code.py"
+        explanation_file_path = document.parent / f"{document.stem}_explanation.md"
+    else:
+        code_file_path = Path.cwd() / "expression_code.py"
+        explanation_file_path = Path.cwd() / "expression_explanation.md"
 
-        return ToolResult(
-            content=[
-                TextContent(type="text", text=f"Explanation: {response.get('explanation', '')}"),
-                TextContent(type="text", text=f"Code: {response.get('code', '')}"),
-            ]
-        )
+    with Path.open(code_file_path, "w", encoding="utf-8") as f:
+        f.write(response.get("code", ""))
 
-    except Exception as e:
-        raise ToolError(f"Failed to check equations in document: {e!s}") from e
+    with Path.open(explanation_file_path, "w", encoding="utf-8") as f:
+        f.write(response.get("explanation", ""))
+
+    return ToolResult(
+        content=[
+            TextContent(type="text", text=f"Explanation: {response.get('explanation', '')}"),
+            TextContent(type="text", text=f"Code: {response.get('code', '')}"),
+        ]
+    )

--- a/axiomatic_mcp/servers/equations/test_server.py
+++ b/axiomatic_mcp/servers/equations/test_server.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from axiomatic_mcp.shared.api_client import AxiomaticAPIClient
+
+sample_pdf_path = Path("/Users/tymek_axai/Desktop/Quantum_basics.pdf")
+sample_markdown_path = Path("/Users/tymek_axai/Desktop/Quantum_basics.md")
+
+sample_task = "Check if the first equation is correct"
+
+with AxiomaticAPIClient() as client:
+    response = client.post(
+        "/equations/derive", data={"task": sample_task}, files={"pdf_file": (sample_pdf_path.name, sample_pdf_path.read_bytes(), "application/pdf")}
+    )
+    print(response)

--- a/axiomatic_mcp/servers/equations/test_server.py
+++ b/axiomatic_mcp/servers/equations/test_server.py
@@ -8,7 +8,11 @@ sample_markdown_path = Path("/Users/tymek_axai/Desktop/Quantum_basics.md")
 sample_task = "Check if the first equation is correct"
 
 with AxiomaticAPIClient() as client:
-    response = client.post(
-        "/equations/derive", data={"task": sample_task}, files={"pdf_file": (sample_pdf_path.name, sample_pdf_path.read_bytes(), "application/pdf")}
+    response_pdf = client.post(
+        "/equations/check", data={"task": sample_task}, files={"pdf_file": (sample_pdf_path.name, sample_pdf_path.read_bytes(), "application/pdf")}
     )
-    print(response)
+    print(response_pdf)
+    print("--------------------------------")
+    print("--------------------------------")
+    response_markdown = client.post("/equations/check", data={"task": sample_task, "markdown": sample_markdown_path.read_text(encoding="utf-8")})
+    print(response_markdown)

--- a/axiomatic_mcp/shared/api_client.py
+++ b/axiomatic_mcp/shared/api_client.py
@@ -3,14 +3,14 @@ from typing import Any
 
 import httpx
 
-API_URL = os.getenv("API_URL", "https://api.axiomatic-ai.com")
+API_URL = os.getenv("API_URL", "http://localhost:8000")
 
 TIMEOUT = 1000
 
 
 class AxiomaticAPIClient:
     def __init__(self):
-        api_key = os.getenv("AXIOMATIC_API_KEY")
+        api_key = "478be067-ad13-4ca7-8c17-5322070172e1"
         if not api_key:
             raise ValueError("AXIOMATIC_API_KEY environment variable is not set")
 

--- a/axiomatic_mcp/shared/utils/file_utils.py
+++ b/axiomatic_mcp/shared/utils/file_utils.py
@@ -1,0 +1,21 @@
+import mimetypes
+
+
+def get_file_type(file_path: str) -> str:
+    """
+    Get the MIME type of a file based on its extension.
+
+    Args:
+        file_path: Path to the file
+
+    Returns:
+        The MIME type of the file, or "application/octet-stream" if unknown
+    """
+    mimetypes.add_type("application/x-ipynb+json", ".ipynb", strict=True)
+    mimetypes.add_type("text/markdown", ".md", strict=True)
+    mimetypes.add_type("text/markdown", ".markdown", strict=True)
+    mimetypes.add_type("text/markdown", ".MD", strict=True)
+    mimetypes.add_type("text/markdown", ".mdx", strict=True)
+    mime_type, _ = mimetypes.guess_type(file_path)
+
+    return mime_type or "application/octet-stream"


### PR DESCRIPTION
This PR is supposed to update the equations server, since equations/derive and equations/check endpoints now accept PDFs. Therefore pdf-to-md conversion is no longer needed. 