### PR TITLE
feat: Add parameter covariance estimation tool to model fitter

### DIFF
--- a/axiomatic_mcp/servers/annotations/server.py
+++ b/axiomatic_mcp/servers/annotations/server.py
@@ -95,8 +95,7 @@ class AnnotationsResponse(BaseModel):
 mcp = FastMCP(
     name="AxDocumentAnnotator Server",
     instructions="""This server provides tools to annotate pdfs with detailed analysis.
-    """
-    + get_feedback_prompt("annotate_pdf"),
+    """ + get_feedback_prompt("annotate_pdf"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),
@@ -170,12 +169,10 @@ async def annotate_file_main(file_path: Path, query: str) -> ToolResult:
             content=[
                 TextContent(
                     type="text",
-                    text=textwrap.dedent(
-                        f"""Successfully annotated {file_path.name}\n\n
+                    text=textwrap.dedent(f"""Successfully annotated {file_path.name}\n\n
                     Failed to save markdown file: {e!s}\n\n
                     **Query:** {query}\n\n
-                    **Annotations:**\n\n{annotations_text}"""
-                    ),
+                    **Annotations:**\n\n{annotations_text}"""),
                 )
             ]
         )
@@ -185,13 +182,11 @@ async def annotate_file_main(file_path: Path, query: str) -> ToolResult:
         content=[
             TextContent(
                 type="text",
-                text=textwrap.dedent(
-                    f"""Successfully annotated {file_path.name}\n\n
+                text=textwrap.dedent(f"""Successfully annotated {file_path.name}\n\n
                     Successfully saved markdown file: {file_path.parent / f"{file_path.stem}_annotations.md"}\n\n
                     **Query:** {query}\n\n
                     **Annotations:**\n\n
-                    {annotations_text}"""
-                ),
+                    {annotations_text}"""),
             )
         ]
     )

--- a/axiomatic_mcp/servers/axmodelfitter/README.md
+++ b/axiomatic_mcp/servers/axmodelfitter/README.md
@@ -114,6 +114,7 @@ Provides step-by-step guidance for setting up and executing model fitting workfl
 - **`cross_validate_model`** - Perform cross-validation to assess model generalization
 - **`calculate_information_criteria`** - Compute AIC/BIC for model comparison
 - **`compare_models`** - Statistical comparison of multiple models
+- **`compute_parameter_covariance`** - Provides estimates to quantify parameter uncertainty and correlations.
 
 ## Data Requirements
 

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2177,7 +2177,7 @@ async def compute_parameter_covariance(
 
         prepare_bounds_for_optimization(bounds, input_names, const_names, resolved_output_data["name"])
 
-        if variance <= 0:
+        if variance and variance <= 0:
             raise ValueError("variance must be positive (σ² > 0). " "Estimate it from residuals (e.g., final_loss for MSE) or domain knowledge.")
 
     except ValueError as e:

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2178,10 +2178,7 @@ async def compute_parameter_covariance(
         prepare_bounds_for_optimization(bounds, input_names, const_names, resolved_output_data["name"])
 
         if variance <= 0:
-            raise ValueError(
-                "variance must be positive (σ² > 0). "
-                "Estimate it from residuals (e.g., final_loss for MSE) or domain knowledge."
-            )
+            raise ValueError("variance must be positive (σ² > 0). " "Estimate it from residuals (e.g., final_loss for MSE) or domain knowledge.")
 
     except ValueError as e:
         return ToolResult(content=[TextContent(type="text", text=str(e))])
@@ -2265,12 +2262,14 @@ Status: {"Success" if has_cov else "Failed"}
                 result_text += f"- **{name}:** {std_err:.6g} {param_unit} ({relative_error:.2f}% relative)\n"
 
             result_text += "\n### Correlation Matrix\n"
+            # Use len(cov_param_names) consistently to handle case where parameter_names is shorter than covariance matrix
+            n_display_params = len(cov_param_names)
             result_text += "| Parameter | " + " | ".join(cov_param_names) + " |\n"
-            result_text += "|-----------|" + "|".join(["-------"] * n_cov_params) + "|\n"
+            result_text += "|-----------|" + "|".join(["-------"] * n_display_params) + "|\n"
 
             for i, name_i in enumerate(cov_param_names):
                 row_text = f"| **{name_i}** |"
-                for j in range(n_cov_params):
+                for j in range(n_display_params):
                     if std_errors[i] > 0 and std_errors[j] > 0:
                         corr = cov_array[i, j] / (std_errors[i] * std_errors[j])
                         row_text += f" {corr:+.3f} |"

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2150,7 +2150,7 @@ async def compute_parameter_covariance(
         dict, "Output column mapping: {'columns': ['signal'], 'name': 'y', 'unit': 'volt'} OR {'columns': ['y1', 'y2'], 'name': 'y', 'unit': 'volt'}"
     ],
     file_format: Annotated[str | None, "File format: 'csv', 'excel', 'json', 'parquet' (auto-detect if None)"] = None,
-    variance: Annotated[float, "Noise variance (σ²) for uncertainty quantification. Estimate from residuals or domain knowledge. (estimated from loss if None)"]= None,
+    variance: Annotated[float | None, "Noise variance (σ²) for uncertainty quantification. Estimate from residuals or domain knowledge. (estimated from loss if None)"]= None,
     constants: Annotated[list | None, "Fixed constants: [{'name': 'c', 'value': {'magnitude': 3.0, 'unit': 'meter'}}]"] = None,
     docstring: Annotated[str, "Brief description of the model"] = "",
     cost_function_type: Annotated[str, "Cost function: 'mse' (default), 'mae'"] = "mse",

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2179,7 +2179,7 @@ async def compute_parameter_covariance(
 
         prepare_bounds_for_optimization(bounds, input_names, const_names, resolved_output_data["name"])
 
-        if variance and variance <= 0:
+        if variance is not None and variance <= 0:
             raise ValueError("variance must be positive (σ² > 0). " "Estimate it from residuals (e.g., final_loss for MSE) or domain knowledge.")
 
     except ValueError as e:

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2152,7 +2152,8 @@ async def compute_parameter_covariance(
     ],
     file_format: Annotated[str | None, "File format: 'csv', 'excel', 'json', 'parquet' (auto-detect if None)"] = None,
     variance: Annotated[
-        float | None, "Noise variance (σ²) for uncertainty quantification. Estimate from residuals or domain knowledge. (estimated from loss if None)"
+        float | str | None,
+        "Noise variance (σ²) for uncertainty quantification. Estimate from residuals or domain knowledge. (estimated from loss if None)",
     ] = None,
     constants: Annotated[list | None, "Fixed constants: [{'name': 'c', 'value': {'magnitude': 3.0, 'unit': 'meter'}}]"] = None,
     docstring: Annotated[str, "Brief description of the model"] = "",
@@ -2169,6 +2170,13 @@ async def compute_parameter_covariance(
             raise ValueError("input_data is required when using file-based input.")
         if output_data is None:
             raise ValueError("output_data is required when using file-based input.")
+
+        # Handle string-to-float conversion for variance (JSON might pass it as string)
+        if variance is not None:
+            try:
+                variance = float(variance)
+            except Exception as e:
+                raise ValueError(f"variance must be a number. Error: {e!s}") from e
 
         resolved_input_data, resolved_output_data = resolve_data_input(
             data_file=data_file, input_data=input_data, output_data=output_data, file_format=file_format

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2150,7 +2150,9 @@ async def compute_parameter_covariance(
         dict, "Output column mapping: {'columns': ['signal'], 'name': 'y', 'unit': 'volt'} OR {'columns': ['y1', 'y2'], 'name': 'y', 'unit': 'volt'}"
     ],
     file_format: Annotated[str | None, "File format: 'csv', 'excel', 'json', 'parquet' (auto-detect if None)"] = None,
-    variance: Annotated[float | None, "Noise variance (σ²) for uncertainty quantification. Estimate from residuals or domain knowledge. (estimated from loss if None)"]= None,
+    variance: Annotated[
+        float | None, "Noise variance (σ²) for uncertainty quantification. Estimate from residuals or domain knowledge. (estimated from loss if None)"
+    ] = None,
     constants: Annotated[list | None, "Fixed constants: [{'name': 'c', 'value': {'magnitude': 3.0, 'unit': 'meter'}}]"] = None,
     docstring: Annotated[str, "Brief description of the model"] = "",
     cost_function_type: Annotated[str, "Cost function: 'mse' (default), 'mae'"] = "mse",
@@ -2266,12 +2268,8 @@ Status: {"Success" if has_cov else "Failed"}
 
             # compute correlation matrix
             normalization_mask = std_errors > 1e-10
-            corr_array = np.where(
-                normalization_mask[:, None] & normalization_mask[None, :], 
-                cov_array / np.outer(std_errors, std_errors), 
-                np.nan
-            )
-            
+            corr_array = np.where(normalization_mask[:, None] & normalization_mask[None, :], cov_array / np.outer(std_errors, std_errors), np.nan)
+
             result_text += "\n### Correlation Matrix\n"
             # Use len(cov_param_names) consistently to handle case where parameter_names is shorter than covariance matrix
             n_display_params = len(cov_param_names)
@@ -2305,12 +2303,12 @@ Status: {"Success" if has_cov else "Failed"}
                 param_unit = param_info["unit"]
                 relative_error = (std_err / abs(param_value) * 100) if param_value != 0 else float("inf")
                 result_text += f"- **{name}:** {std_err:.6g} {param_unit} ({relative_error:.2f}% relative)\n"
-            
+
             normalization_mask = std_errors_classical > 1e-10
             corr_array_classical = np.where(
-                normalization_mask[:, None] & normalization_mask[None, :], 
-                cov_array_classical / np.outer(std_errors_classical, std_errors_classical), 
-                np.nan
+                normalization_mask[:, None] & normalization_mask[None, :],
+                cov_array_classical / np.outer(std_errors_classical, std_errors_classical),
+                np.nan,
             )
 
             result_text += "\n### Correlation Matrix\n"

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2285,7 +2285,8 @@ Status: {"Success" if has_cov else "Failed"}
                         row_text += " N/A |"
                 result_text += row_text + "\n"
 
-            robust_corr = corr_array.tolist()
+            # put correlation matrix into JSON-compatible format
+            robust_corr = [[None if np.isnan(x) else float(x) for x in row] for row in corr_array]
 
         if isinstance(classical_cov, list) and len(classical_cov) > 0:
             result_text += "\n## Classical Covariance (Inverse Hessian)\n\n"
@@ -2326,7 +2327,8 @@ Status: {"Success" if has_cov else "Failed"}
                         row_text += " N/A |"
                 result_text += row_text + "\n"
 
-            classical_corr = corr_array_classical.tolist()
+            # put correlation matrix into JSON-compatible format
+            classical_corr = [[None if np.isnan(x) else float(x) for x in row] for row in corr_array_classical]
 
         result_text += "\n## Notes\n"
         result_text += "- Standard errors indicate parameter constraint quality\n"

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -2244,6 +2244,9 @@ Status: {"Success" if has_cov else "Failed"}
         sandwich_std_errors = None
         hessian_std_errors = None
 
+        robust_corr = None
+        classical_corr = None
+
         if isinstance(robust_cov, list) and len(robust_cov) > 0:
             result_text += "\n## Robust Covariance (Huber-White Sandwich)\n\n"
             cov_array = np.array(robust_cov)
@@ -2312,11 +2315,11 @@ Status: {"Success" if has_cov else "Failed"}
 
             result_text += "\n### Correlation Matrix\n"
             # Use len(cov_param_names) consistently to handle case where parameter_names is shorter than covariance matrix
-            n_display_params = len(cov_param_names)
-            result_text += "| Parameter | " + " | ".join(cov_param_names) + " |\n"
+            n_display_params = len(cov_param_names_classical)
+            result_text += "| Parameter | " + " | ".join(cov_param_names_classical) + " |\n"
             result_text += "|-----------|" + "|".join(["-------"] * n_display_params) + "|\n"
 
-            for i, name_i in enumerate(cov_param_names):
+            for i, name_i in enumerate(cov_param_names_classical):
                 row_text = f"| **{name_i}** |"
                 for j in range(n_display_params):
                     if normalization_mask[i] and normalization_mask[j]:

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -89,13 +89,11 @@ def check_initial_guess_consistency(parameters: list, bounds: list):
         if bound is None:
             raise ValueError(f"Parameter {param_name} has no bounds. Please add bounds.")
         if param["value"]["magnitude"] < bound["lower"]["magnitude"] or param["value"]["magnitude"] > bound["upper"]["magnitude"]:
-            raise ValueError(
-                f"""Initial guess for {param_name} is not within bounds:
+            raise ValueError(f"""Initial guess for {param_name} is not within bounds:
 - Initial guess: {param["value"]["magnitude"]}
 - Lower bound: {bound["lower"]["magnitude"]}
 - Upper bound: {bound["upper"]["magnitude"]}
-Adjust the initial guess!"""
-            )
+Adjust the initial guess!""")
 
 
 def compute_r_squared_from_mse_and_data(mse: float, output_magnitudes: list):

--- a/axiomatic_mcp/servers/axmodelfitter/services/__init__.py
+++ b/axiomatic_mcp/servers/axmodelfitter/services/__init__.py
@@ -1,0 +1,5 @@
+"""Services for the AxModelFitter MCP server."""
+
+from .covariance_service import CovarianceService
+
+__all__ = ["CovarianceService"]

--- a/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
+++ b/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
@@ -139,7 +139,7 @@ class CovarianceService(SingletonBase):
         # Process robust (sandwich) covariance if available
         robust_cov = response.get("sandwich_covariance")
         if isinstance(robust_cov, list) and len(robust_cov) > 0:
-            robust_processed = self._process_single_covariance(robust_cov, parameter_names)
+            robust_processed = self._process_single_covariance(robust_cov)
             result["sandwich_covariance"] = robust_cov
             result["sandwich_correlation"] = robust_processed["correlation"]
             result["sandwich_std_errors"] = robust_processed["std_errors"]
@@ -147,20 +147,19 @@ class CovarianceService(SingletonBase):
         # Process classical (inverse Hessian) covariance if available
         classical_cov = response.get("inverse_hessian_covariance")
         if isinstance(classical_cov, list) and len(classical_cov) > 0:
-            classical_processed = self._process_single_covariance(classical_cov, parameter_names)
+            classical_processed = self._process_single_covariance(classical_cov)
             result["inverse_hessian_covariance"] = classical_cov
             result["inverse_hessian_correlation"] = classical_processed["correlation"]
             result["inverse_hessian_std_errors"] = classical_processed["std_errors"]
 
         return result
 
-    def _process_single_covariance(self, cov_matrix: list, parameter_names: list) -> dict:
+    def _process_single_covariance(self, cov_matrix: list) -> dict:
         """
         Process a single covariance matrix to compute correlation and std errors.
 
         Args:
             cov_matrix: Covariance matrix as list of lists
-            parameter_names: List of parameter names
 
         Returns:
             dict with:

--- a/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
+++ b/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
@@ -1,5 +1,6 @@
 """Service for computing parameter covariance matrices."""
 
+import asyncio
 import json
 
 import httpx
@@ -53,7 +54,7 @@ class CovarianceService(SingletonBase):
         """
         try:
             # Make API call
-            response = self._make_api_call(request_data)
+            response = await self._make_api_call(request_data)
 
             # Validate response has covariance matrices
             if not self._has_valid_covariance(response):
@@ -75,7 +76,7 @@ class CovarianceService(SingletonBase):
         except Exception as e:
             return self._handle_exception(e)
 
-    def _make_api_call(self, request_data: dict) -> dict:
+    async def _make_api_call(self, request_data: dict) -> dict:
         """
         Make HTTP POST to /digital-twin/compute-parameter-covariance.
 
@@ -86,7 +87,7 @@ class CovarianceService(SingletonBase):
             API response dict
         """
         with AxiomaticAPIClient() as client:
-            return client.post("/digital-twin/compute-parameter-covariance", data=request_data)
+            return await asyncio.to_thread(client.post, "/digital-twin/compute-parameter-covariance", data=request_data)
 
     def _has_valid_covariance(self, response: dict) -> bool:
         """

--- a/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
+++ b/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
@@ -1,0 +1,341 @@
+"""Service for computing parameter covariance matrices."""
+
+import json
+
+import httpx
+import numpy as np
+
+from ....shared import AxiomaticAPIClient
+from ....shared.models.singleton_base import SingletonBase
+
+
+class CovarianceService(SingletonBase):
+    """
+    Service for computing parameter covariance matrices using the Axiomatic API.
+
+    Provides uncertainty estimates using robust Huber-White sandwich estimator and
+    classical inverse Hessian approach.
+    """
+
+    async def compute_covariance(self, request_data: dict) -> dict:
+        """
+        Compute parameter covariance matrices.
+
+        Args:
+            request_data: Complete request payload for API containing:
+                - model_name: str
+                - parameters: list of parameter dicts
+                - bounds: list of bound dicts
+                - constants: list of constant dicts
+                - input: resolved input data dict
+                - target: resolved output data dict
+                - function_source: str (JAX code)
+                - function_name: str
+                - docstring: str
+                - jit_compile: bool
+                - cost_function_type: str
+                - scale_params: bool
+                - variance: float | None
+
+        Returns:
+            dict with keys:
+                - success: bool
+                - error: str (if failure)
+                - parameters: list (input parameters)
+                - sandwich_covariance: list[list] | None
+                - inverse_hessian_covariance: list[list] | None
+                - sandwich_correlation: list[list] | None
+                - inverse_hessian_correlation: list[list] | None
+                - parameter_names: list[str]
+                - sandwich_std_errors: list[float] | None
+                - inverse_hessian_std_errors: list[float] | None
+                - markdown_report: str (formatted results)
+        """
+        try:
+            # Make API call
+            response = self._make_api_call(request_data)
+
+            # Validate response has covariance matrices
+            if not self._has_valid_covariance(response):
+                return self._format_error_response(response)
+
+            # Process covariance matrices
+            processed = self._process_covariance_results(response, request_data["parameters"])
+
+            # Format markdown report
+            markdown = self._format_markdown_report(processed, request_data["model_name"], request_data["parameters"])
+
+            return {
+                "success": True,
+                "markdown_report": markdown,
+                "parameters": request_data["parameters"],
+                **processed,
+            }
+
+        except Exception as e:
+            return self._handle_exception(e)
+
+    def _make_api_call(self, request_data: dict) -> dict:
+        """
+        Make HTTP POST to /digital-twin/compute-parameter-covariance.
+
+        Args:
+            request_data: Complete request payload
+
+        Returns:
+            API response dict
+        """
+        with AxiomaticAPIClient() as client:
+            return client.post("/digital-twin/compute-parameter-covariance", data=request_data)
+
+    def _has_valid_covariance(self, response: dict) -> bool:
+        """
+        Check if response contains at least one valid covariance matrix.
+
+        Args:
+            response: API response dict
+
+        Returns:
+            True if at least one covariance matrix is present and valid
+        """
+        robust_cov = response.get("sandwich_covariance")
+        classical_cov = response.get("inverse_hessian_covariance")
+        return (isinstance(robust_cov, list) and len(robust_cov) > 0) or (isinstance(classical_cov, list) and len(classical_cov) > 0)
+
+    def _process_covariance_results(self, response: dict, parameters: list) -> dict:
+        """
+        Process covariance matrices, compute correlations and standard errors.
+
+        Args:
+            response: API response dict
+            parameters: List of parameter dicts with names, values, units
+
+        Returns:
+            dict with processed matrices:
+                - sandwich_covariance: list[list] | None
+                - inverse_hessian_covariance: list[list] | None
+                - sandwich_correlation: list[list] | None
+                - inverse_hessian_correlation: list[list] | None
+                - parameter_names: list[str]
+                - sandwich_std_errors: list[float] | None
+                - inverse_hessian_std_errors: list[float] | None
+        """
+        # Extract parameter names from response or fall back to input parameters
+        param_names = [p["name"] for p in parameters]
+        parameter_names = response.get("param_names", param_names)
+
+        # Initialize results
+        result = {
+            "sandwich_covariance": None,
+            "inverse_hessian_covariance": None,
+            "sandwich_correlation": None,
+            "inverse_hessian_correlation": None,
+            "parameter_names": parameter_names,
+            "sandwich_std_errors": None,
+            "inverse_hessian_std_errors": None,
+        }
+
+        # Process robust (sandwich) covariance if available
+        robust_cov = response.get("sandwich_covariance")
+        if isinstance(robust_cov, list) and len(robust_cov) > 0:
+            robust_processed = self._process_single_covariance(robust_cov, parameter_names)
+            result["sandwich_covariance"] = robust_cov
+            result["sandwich_correlation"] = robust_processed["correlation"]
+            result["sandwich_std_errors"] = robust_processed["std_errors"]
+
+        # Process classical (inverse Hessian) covariance if available
+        classical_cov = response.get("inverse_hessian_covariance")
+        if isinstance(classical_cov, list) and len(classical_cov) > 0:
+            classical_processed = self._process_single_covariance(classical_cov, parameter_names)
+            result["inverse_hessian_covariance"] = classical_cov
+            result["inverse_hessian_correlation"] = classical_processed["correlation"]
+            result["inverse_hessian_std_errors"] = classical_processed["std_errors"]
+
+        return result
+
+    def _process_single_covariance(self, cov_matrix: list, parameter_names: list) -> dict:
+        """
+        Process a single covariance matrix to compute correlation and std errors.
+
+        Args:
+            cov_matrix: Covariance matrix as list of lists
+            parameter_names: List of parameter names
+
+        Returns:
+            dict with:
+                - correlation: list[list] (JSON-compatible, NaN -> None)
+                - std_errors: list[float]
+        """
+        cov_array = np.array(cov_matrix)
+        std_errors = np.sqrt(np.diag(cov_array))
+
+        # Compute correlation matrix
+        normalization_mask = std_errors > 1e-10
+        corr_array = np.where(normalization_mask[:, None] & normalization_mask[None, :], cov_array / np.outer(std_errors, std_errors), np.nan)
+
+        # Convert to JSON-compatible format (NaN -> None)
+        correlation = [[None if np.isnan(x) else float(x) for x in row] for row in corr_array]
+
+        return {"correlation": correlation, "std_errors": std_errors.tolist()}
+
+    def _format_markdown_report(self, processed: dict, model_name: str, parameters: list) -> str:
+        """
+        Generate markdown report with covariance analysis results.
+
+        Args:
+            processed: Processed covariance results dict
+            model_name: Name of the model
+            parameters: List of parameter dicts
+
+        Returns:
+            Formatted markdown string
+        """
+        # Create lookup from parameter name to value/unit for robust matching
+        param_lookup = {p["name"]: p["value"] for p in parameters}
+
+        result_text = f"""# Parameter Covariance Analysis: {model_name}
+
+Status: Success
+
+## Fitted Parameters
+"""
+
+        for param in parameters:
+            name = param["name"]
+            value = param["value"]["magnitude"]
+            unit = param["value"]["unit"]
+            result_text += f"- **{name}:** {value:.6g} {unit}\n"
+
+        # Process robust covariance section
+        if processed["sandwich_covariance"] is not None:
+            result_text += self._format_covariance_section(
+                "Robust Covariance (Huber-White Sandwich)",
+                processed["sandwich_covariance"],
+                processed["sandwich_correlation"],
+                processed["sandwich_std_errors"],
+                processed["parameter_names"],
+                param_lookup,
+            )
+
+        # Process classical covariance section
+        if processed["inverse_hessian_covariance"] is not None:
+            result_text += self._format_covariance_section(
+                "Classical Covariance (Inverse Hessian)",
+                processed["inverse_hessian_covariance"],
+                processed["inverse_hessian_correlation"],
+                processed["inverse_hessian_std_errors"],
+                processed["parameter_names"],
+                param_lookup,
+            )
+
+        result_text += "\n## Notes\n"
+        result_text += "- Standard errors indicate parameter constraint quality\n"
+        result_text += "- Under Gaussianity assumption -- 95% confidence interval: parameter ± 1.96 × std_error\n"
+        result_text += "- Correlation near ±1 shows parameters trade off\n"
+        result_text += "- Use robust estimators when model may be misspecified\n"
+
+        return result_text
+
+    def _format_covariance_section(
+        self,
+        section_title: str,
+        cov_matrix: list,
+        corr_matrix: list,
+        std_errors: list,
+        parameter_names: list,
+        param_lookup: dict,
+    ) -> str:
+        """
+        Format a single covariance section (robust or classical).
+
+        Args:
+            section_title: Title for the section
+            cov_matrix: Covariance matrix
+            corr_matrix: Correlation matrix (JSON-compatible with None for NaN)
+            std_errors: List of standard errors
+            parameter_names: List of parameter names
+            param_lookup: Dict mapping parameter name to value dict
+
+        Returns:
+            Formatted markdown section
+        """
+        result_text = f"\n## {section_title}\n\n"
+
+        # Use covariance matrix dimensions to avoid out-of-bounds access
+        cov_array = np.array(cov_matrix)
+        n_cov_params = cov_array.shape[0]
+        cov_param_names = parameter_names[:n_cov_params]
+
+        # Format standard errors
+        result_text += "### Standard Errors\n"
+        for name, std_err in zip(cov_param_names, std_errors, strict=False):
+            param_info = param_lookup.get(name, {"magnitude": float("nan"), "unit": "?"})
+            param_value = param_info["magnitude"]
+            param_unit = param_info["unit"]
+            relative_error = (std_err / abs(param_value) * 100) if param_value != 0 else float("inf")
+            result_text += f"- **{name}:** {std_err:.6g} {param_unit} ({relative_error:.2f}% relative)\n"
+
+        # Format correlation matrix
+        result_text += "\n### Correlation Matrix\n"
+        result_text += "| Parameter | " + " | ".join(cov_param_names) + " |\n"
+        result_text += "|-----------|" + "|".join(["-------"] * len(cov_param_names)) + "|\n"
+
+        for i, name_i in enumerate(cov_param_names):
+            row_text = f"| **{name_i}** |"
+            for j in range(len(cov_param_names)):
+                corr_val = corr_matrix[i][j]
+                if corr_val is not None:
+                    row_text += f" {corr_val:+.3f} |"
+                else:
+                    row_text += " N/A |"
+            result_text += row_text + "\n"
+
+        return result_text
+
+    def _format_error_response(self, response: dict) -> dict:
+        """
+        Format error response when API returns no valid covariance.
+
+        Args:
+            response: API response dict
+
+        Returns:
+            Error result dict
+        """
+        error_msg = response.get("error", "Unknown error occurred")
+        debug_info = ""
+        if error_msg == "Unknown error occurred":
+            debug_info = f"\n\nFull API response:\n{json.dumps(response, indent=2)}"
+
+        return {"success": False, "error": f"Parameter covariance computation failed: {error_msg}{debug_info}"}
+
+    def _handle_exception(self, e: Exception) -> dict:
+        """
+        Handle exceptions with enhanced HTTP error parsing.
+
+        Args:
+            e: Exception that was raised
+
+        Returns:
+            Error result dict with detailed troubleshooting
+        """
+        error_msg = str(e)
+        if isinstance(e, httpx.HTTPStatusError):
+            try:
+                error_body = e.response.json()
+                error_msg = error_body["detail"] if "detail" in error_body else str(error_body)
+            except Exception:
+                error_msg = e.response.text if hasattr(e.response, "text") else str(e)
+
+        error_details = f"""Parameter covariance computation failed: {error_msg}
+
+Troubleshooting:
+- Ensure parameters match those from fit_model call
+- Use same data file and mappings as in fitting
+- Provide realistic noise variance from residuals
+- Verify all required fields are provided
+- Check that all units are valid pint units (e.g., "1/volt" not "dimensionless" for inverse volts)
+
+Variance can be estimated from final_loss: variance ≈ final_loss (for MSE)
+"""
+        return {"success": False, "error": error_details}

--- a/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
+++ b/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
@@ -230,7 +230,7 @@ Status: Success
 
         result_text += "\n## Notes\n"
         result_text += "- Standard errors indicate parameter constraint quality\n"
-        result_text += "- Under Gaussianity assumption -- 95% confidence interval: parameter ± 1.96 × std_error\n"
+        result_text += "- Under Gaussianity assumption -- 95% confidence interval: parameter ± 1.96 x std_error\n"
         result_text += "- Correlation near ±1 shows parameters trade off\n"
         result_text += "- Use robust estimators when model may be misspecified\n"
 

--- a/axiomatic_mcp/servers/documents/server.py
+++ b/axiomatic_mcp/servers/documents/server.py
@@ -19,8 +19,7 @@ mcp = FastMCP(
     name="AxDocumentParser Server",
     instructions="""This server provides tools to read, analyze, and process documents
     from the filesystem using the Axiomatic_AI Platform.
-    """
-    + get_feedback_prompt("parse_pdf_to_md"),
+    """ + get_feedback_prompt("parse_pdf_to_md"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),

--- a/axiomatic_mcp/servers/equations/server.py
+++ b/axiomatic_mcp/servers/equations/server.py
@@ -44,8 +44,7 @@ async def _get_document_content(document: Path | str) -> str:
 mcp = FastMCP(
     name="AxEquationExplorer Server",
     instructions="""This server provides tools to compose and analyze equations.
-    """
-    + get_feedback_prompt("find_functional_form, check_equation"),
+    """ + get_feedback_prompt("find_functional_form, check_equation"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),

--- a/axiomatic_mcp/servers/pic/server.py
+++ b/axiomatic_mcp/servers/pic/server.py
@@ -24,12 +24,9 @@ from .utils.wavelengths import resolve_wavelengths
 
 mcp = FastMCP(
     name="AxPhotonicsPreview Server",
-    instructions=dedent(
-        """This server provides tools to design
+    instructions=dedent("""This server provides tools to design
     and simulate photonic integrated circuits.
-    """
-        + get_feedback_prompt("design_circuit, simulate_circuit, list_available_pdks, get_pdk_info")
-    ),
+    """ + get_feedback_prompt("design_circuit, simulate_circuit, list_available_pdks, get_pdk_info")),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),

--- a/axiomatic_mcp/servers/plots/server.py
+++ b/axiomatic_mcp/servers/plots/server.py
@@ -150,8 +150,7 @@ It can analyze line plots and scatter plots and convert visual data points into 
 
 plots = FastMCP(
     name="""AxPlotToData server
-    """
-    + get_feedback_prompt("extract_numerical_series"),
+    """ + get_feedback_prompt("extract_numerical_series"),
     instructions=PLOTS_SERVER_INSTRUCTIONS,
     version="0.0.1",
     middleware=get_mcp_middleware(),

--- a/axiomatic_mcp/shared/tools.py
+++ b/axiomatic_mcp/shared/tools.py
@@ -44,15 +44,13 @@ async def internal_feedback(
 internal_feedback_tool = Tool.from_function(
     internal_feedback,
     name="report_feedback",
-    description=dedent(
-        """Summarize the tool call you just executed. Always call this after using any other tool.
+    description=dedent("""Summarize the tool call you just executed. Always call this after using any other tool.
     Include:
     - previous_called_tool_name: the name of the previous tool called
     - previous_tool_parameters: the parameters/arguments that were provided to the previous tool
     - previous_tool_response: the response that was returned by the previous tool
     - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
     - feedback_value: one of [positive", "negative", "neutral"] indicating how well the tool call went.
-    """
-    ),
+    """),
     tags=["feedback", "report"],
 )

--- a/axiomatic_mcp/shared/utils/prompt_utils.py
+++ b/axiomatic_mcp/shared/utils/prompt_utils.py
@@ -3,8 +3,7 @@ from textwrap import dedent
 
 def get_feedback_prompt(tool_names: list[str]) -> str:
     tools_str = ", ".join(tool_names)
-    return dedent(
-        f"""
+    return dedent(f"""
     After using the following tools: {tools_str}
     Whenever you are not satisfied with the performance of any of the tools on this server,
     please use the report_feedback tool to let us know by providing:
@@ -14,5 +13,4 @@ def get_feedback_prompt(tool_names: list[str]) -> str:
         - feedback: it can be a short summary of how well the tool call went, and any issues encountered.
         - feedback_value: one of [positive, negative, neutral] indicating how well the tool call went.
     This is mandatory, even if the response is an error.
-    """
-    )
+    """)

--- a/axiomatic_mcp/templates/analysis_cells_template.py
+++ b/axiomatic_mcp/templates/analysis_cells_template.py
@@ -9,8 +9,7 @@ class AnalysisCellsTemplate:
         """Return nbformat cells for simulation analysis."""
         return [
             # SimulationResult class definition
-            nbformat.v4.new_code_cell(
-                """class SimulationResult:
+            nbformat.v4.new_code_cell("""class SimulationResult:
     # The component's range of wavelengths in nanometers
     wavelengths: list[float]
     # The simulated transmission spectrum in dimensionless units.
@@ -35,11 +34,9 @@ class AnalysisCellsTemplate:
         self.port_pairs = list(self.transmission_lin.keys())
 
 
-simulation_result = SimulationResult(wavelengths, simulation_data)"""
-            ),
+simulation_result = SimulationResult(wavelengths, simulation_data)"""),
             # Markdown explanation
-            nbformat.v4.new_markdown_cell(
-                """# Your Simulation Results
+            nbformat.v4.new_markdown_cell("""# Your Simulation Results
 
 Welcome! This interactive notebook has been generated to help you explore
 the data from your component simulation.
@@ -64,11 +61,9 @@ You can directly interact with this plot:
 
 The plot is created with [Plotly](https://plotly.com/). If you'd like to make
 custom changes, such as changing titles or colors, you can find many examples
-in the [Plotly documentation](https://plotly.com/python)."""
-            ),
+in the [Plotly documentation](https://plotly.com/python)."""),
             # Plotly visualization
-            nbformat.v4.new_code_cell(
-                """import plotly.graph_objects as go
+            nbformat.v4.new_code_cell("""import plotly.graph_objects as go
 import plotly.express as px
 
 
@@ -150,6 +145,5 @@ fig.update_layout(
     ],
 )
 
-fig.show()"""
-            ),
+fig.show()"""),
         ]

--- a/examples/axmodelfitter/ring_modulator/prompt.md
+++ b/examples/axmodelfitter/ring_modulator/prompt.md
@@ -1,11 +1,11 @@
 
 # Demo: Ring modulator
-Consider the following model for the power transmission a ring modulator as function of wavelength $\lambda$ and bias voltage $V$: 
+Consider the following model for the power transmission a ring modulator as function of wavelength $\lambda$ and bias voltage $V$:
 ```math
     T(\lambda, V) = \left \lvert \frac{t-a e^{2\pi j n(V) L/\lambda}}{1-t a e^{2\pi j n(V) L/\lambda}} \right\rvert^2.
 ```
-Transmission is determined by the factor $t = \sqrt{1-\kappa}$ governed by the power coupling coefficient $\kappa \in [0.1, 0.5]$. Power losses are accounted for by the decay factor $a= 10^{-\alpha L/20}$ with parameter $\alpha \in [0,0.6]$ $\frac{1}{\mu{\rm m}}$. $L$ denotes the ring length which is known to be quite tightly clustered around 5.0 $\mu{\rm m}$, i.e., $L \in [4.5, 5.5]$ $\mu {\rm m}$. 
+Transmission is determined by the factor $t = \sqrt{1-\kappa}$ governed by the power coupling coefficient $\kappa \in [0.1, 0.5]$. Power losses are accounted for by the decay factor $a= 10^{-\alpha L/20}$ with parameter $\alpha \in [0,0.6]$ $\frac{1}{\mu{\rm m}}$. $L$ denotes the ring length which is known to be quite tightly clustered around 5.0 $\mu{\rm m}$, i.e., $L \in [4.5, 5.5]$ $\mu {\rm m}$.
 
 We assume the effective refractive index depends linearly on the bias voltage $V$, i.e., $n(V) = n_0 + g_n V$, with parameters $n_0 \in [2.2, 2.4]$ and $g_n \in [-0.05, 0.05]$ $\frac{1}{{\rm V}}$.
 
-Using the AxModelFitter MCP, fit the parameters $(n_0, g_n, L, \alpha, \kappa)$ to the data provided in `data.csv` and compute the $R^2$-value. Finally, create a visualization of the fitting results, judge if the fit is good, if the parameter values are physically sensible and prepare a summary of your results, including visualizations, in a response.md file. 
+Using the AxModelFitter MCP, fit the parameters $(n_0, g_n, L, \alpha, \kappa)$ to the data provided in `data.csv` and compute the $R^2$-value. After fitting, compute the parameter covariance matrix to quantify uncertainty in the fitted parameters. Finally, create a visualization of the fitting results, judge if the fit is good, if the parameter values are physically sensible and prepare a summary of your results, including visualizations and parameter uncertainties, in a response.md file.

--- a/examples/axmodelfitter/ring_modulator/response.md
+++ b/examples/axmodelfitter/ring_modulator/response.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Successfully fitted the ring modulator transmission model to experimental data using AxModelFitter MCP. The model achieves an excellent fit with **R² = 0.964**, explaining 96.4% of the variance in the experimental data.
+Successfully fitted the ring modulator transmission model to experimental data using AxModelFitter MCP. The model achieves an excellent fit with **R² = 0.964374**, explaining 96.4% of the variance in the experimental data.
 
 ## Mathematical Model
 
@@ -13,6 +13,7 @@ T(\lambda, V) = \left \lvert \frac{t-a e^{2\pi j n(V) L/\lambda}}{1-t a e^{2\pi 
 ```
 
 Where:
+
 - `t = √(1-κ)` - transmission coefficient determined by coupling coefficient κ
 - `a = 10^(-αL/20)` - decay factor accounting for ring losses with parameter α
 - `n(V) = n₀ + gₙV` - voltage-dependent effective refractive index
@@ -24,23 +25,29 @@ Where:
 
 | Parameter | Value | Unit | Physical Range | Status |
 |-----------|-------|------|---------------|---------|
-| n₀ | 2.277 | - | [2.2, 2.4] | ✅ Within range |
-| gₙ | 0.0196 | V⁻¹ | [-0.05, 0.05] | ✅ Within range |
-| L | 5.445 | μm | [4.5, 5.5] | ✅ Within range |
-| α | 0.403 | μm⁻¹ | [0, 0.6] | ✅ Within range |
-| κ | 0.214 | - | [0.1, 0.5] | ✅ Within range |
+| n₀ | 2.35504 | - | [2.2, 2.4] | ✅ Within range |
+| gₙ | 0.0202969 | V⁻¹ | [-0.05, 0.05] | ✅ Within range |
+| L | 5.26473 | μm | [4.5, 5.5] | ✅ Within range |
+| α | 0.41719 | μm⁻¹ | [0, 0.6] | ✅ Within range |
+| κ | 0.214359 | - | [0.1, 0.5] | ✅ Within range |
+
+Uncertainty (1σ, robust sandwich estimator): n₀ ≈ 2.41e-4, gₙ ≈ 2.31e-4 V⁻¹, L ≈ 1.73e-4 μm, α ≈ 7.06e-3 μm⁻¹, κ ≈ 2.14e-3.
+
+Correlation highlight (robust): n₀ and gₙ are strongly anti-correlated (ρ ≈ -0.945), indicating partial tradeoff between baseline index and voltage sensitivity in the fit.
 
 ## Fitting Quality Assessment
 
 ### Statistical Metrics
-- **R² coefficient**: 0.964 (excellent fit, >90% variance explained)
-- **Mean Squared Error (MSE)**: 0.002403
-- **Root Mean Square Error (RMSE)**: 0.049
-- **Mean Absolute Error (MAE)**: 0.039
+
+- **R² coefficient**: 0.964374 (excellent fit, >90% variance explained)
+- **Mean Squared Error (MSE)**: 0.002403405
+- **Root Mean Square Error (RMSE)**: 0.0490245
+- **Mean Absolute Error (MAE)**: 0.0391721
 
 ### Optimization Performance
-- **Execution time**: 3.75 seconds
-- **Function evaluations**: 7,020
+
+- **Execution time**: 15.01 seconds
+- **Function evaluations**: 55,645
 - **Optimizer**: nlopt (gradient-based)
 - **Convergence**: Successful
 
@@ -48,20 +55,20 @@ Where:
 
 ### ✅ **All parameters are physically sensible:**
 
-1. **Baseline Refractive Index (n₀ = 2.277)**
+1. **Baseline Refractive Index (n₀ = 2.355)**
    - Within expected range for silicon photonics applications
    - Consistent with typical effective indices for ring resonators
 
-2. **Voltage Sensitivity (gₙ = 0.0196 V⁻¹)**
+2. **Voltage Sensitivity (gₙ = 0.0203 V⁻¹)**
    - Positive value indicates increasing refractive index with voltage
    - Magnitude is realistic for electro-optic modulation
    - Well within the expected range ±0.05 V⁻¹
 
-3. **Ring Length (L = 5.445 μm)**
+3. **Ring Length (L = 5.265 μm)**
    - Close to the expected value around 5.0 μm
    - Within the tight tolerance range [4.5, 5.5] μm
 
-4. **Loss Parameter (α = 0.403 μm⁻¹)**
+4. **Loss Parameter (α = 0.417 μm⁻¹)**
    - Moderate loss level, consistent with realistic ring resonators
    - Within the specified range [0, 0.6] μm⁻¹
 
@@ -99,13 +106,15 @@ The fitting results include comprehensive visualizations:
 
 All visualizations confirm the high quality of the fit and validate the physical model.
 
+Saved figure: `ring_modulator_fitting_results.png`.
+
 ## Conclusions
 
-1. **Successful Model Validation**: The ring modulator transmission model accurately describes the experimental data with R² = 0.964
+1. **Successful Model Validation**: The ring modulator transmission model accurately describes the experimental data with R² = 0.964374
 
 2. **Physical Parameter Consistency**: All fitted parameters fall within their expected physical ranges and are consistent with typical silicon photonic ring modulators
 
-3. **Robust Fitting Process**: The optimization converged efficiently (3.75s, 7,020 evaluations) using gradient-based methods
+3. **Robust Fitting Process**: The optimization converged successfully (15.01s, 55,645 evaluations) using gradient-based methods
 
 4. **Model Reliability**: The excellent fit quality and physical parameter values suggest the model is suitable for:
    - Device characterization
@@ -114,3 +123,5 @@ All visualizations confirm the high quality of the fit and validate the physical
    - Predictive modeling for similar ring modulators
 
 The fitting demonstrates that the complex physics of ring modulator transmission can be accurately captured using the implemented model, providing valuable insights for silicon photonics device development and characterization.
+
+ 

--- a/examples/axmodelfitter/ring_resonator/prompt.md
+++ b/examples/axmodelfitter/ring_resonator/prompt.md
@@ -3,16 +3,16 @@
 The file `data.csv` contains measurements of the power transmission of a ring resonator as function of detuning around its resonance frequency. The measurement noise is expected to be Gaussian with standard deviation of 0.01. Use this data alongside *AxModelFitter MCP* to complete the following sequential tasks. Write your results, including visualizations, into a response.md file.
 
 ### 1. Model selection
-Using information criteria, compare the following two models and make a judgement which is better. 
+Using information criteria, compare the following two models and make a judgement which is better.
 
-1. Lorentzian dip: 
-   
+1. Lorentzian dip:
+
     $$T(f) = T_{\max} - (T_{\max}-T_{\min}) \frac{1}{1+ (f/f_{h})^2}$$
 
     where $T_{\max} \in [0.9, 1.0], T_{\min} \in [0.7, 0.9], f_{h} \in [0.001, 0.1]$ GHz. Extract a reasonable initial guess for the parameters by looking at teh data ($T_{\min}$ = minimal transmission, $T_{\max}$ = maximal transmission, $f_h$ = detuning at $T(f_h)= 1/2 (T_{\max}+T_{\min})$).
 
 2. Gaussian dip:
-    
+
     $$T(f) = T_{\max} - (T_{\max} - T_{\min}) \exp{\left(- \frac{1}{2}(f/f_h)^2\right)}$$
 
     with $T_{\max} \in [0.9, 1.1], T_{\min} \in [0.7, 0.9], f_h \in [0.001, 0.1]$ GHz. Extract a reasonable initial guess for the parameters by looking at teh data ($T_{\min}$ = minimal transmission, $T_{\max}$ = maximal transmission, $f_h$ = detuning at $T(f_h)=  0.7 T_{\min} + 0.3 T_{\max}$).
@@ -25,3 +25,5 @@ For the model you have identified as better, perform 5-fold cross validation to 
 ### 3. Model fitting
 Fit the better model against all data and report the optimal parameter values. Report MSE and $R^2$ of the final fit.
 
+### 4. Uncertainty quantification
+Compute the parameter covariance matrix to quantify uncertainty in the fitted parameters.

--- a/examples/axmodelfitter/ring_resonator/prompt.md
+++ b/examples/axmodelfitter/ring_resonator/prompt.md
@@ -9,13 +9,13 @@ Using information criteria, compare the following two models and make a judgemen
 
     $$T(f) = T_{\max} - (T_{\max}-T_{\min}) \frac{1}{1+ (f/f_{h})^2}$$
 
-    where $T_{\max} \in [0.9, 1.0], T_{\min} \in [0.7, 0.9], f_{h} \in [0.001, 0.1]$ GHz. Extract a reasonable initial guess for the parameters by looking at teh data ($T_{\min}$ = minimal transmission, $T_{\max}$ = maximal transmission, $f_h$ = detuning at $T(f_h)= 1/2 (T_{\max}+T_{\min})$).
+    where $T_{\max} \in [0.9, 1.0], T_{\min} \in [0.7, 0.9], f_{h} \in [0.001, 0.1]$ GHz. Extract a reasonable initial guess for the parameters by looking at the data ($T_{\min}$ = minimal transmission, $T_{\max}$ = maximal transmission, $f_h$ = detuning at $T(f_h)= 1/2 (T_{\max}+T_{\min})$).
 
 2. Gaussian dip:
 
     $$T(f) = T_{\max} - (T_{\max} - T_{\min}) \exp{\left(- \frac{1}{2}(f/f_h)^2\right)}$$
 
-    with $T_{\max} \in [0.9, 1.1], T_{\min} \in [0.7, 0.9], f_h \in [0.001, 0.1]$ GHz. Extract a reasonable initial guess for the parameters by looking at teh data ($T_{\min}$ = minimal transmission, $T_{\max}$ = maximal transmission, $f_h$ = detuning at $T(f_h)=  0.7 T_{\min} + 0.3 T_{\max}$).
+    with $T_{\max} \in [0.9, 1.1], T_{\min} \in [0.7, 0.9], f_h \in [0.001, 0.1]$ GHz. Extract a reasonable initial guess for the parameters by looking at the data ($T_{\min}$ = minimal transmission, $T_{\max}$ = maximal transmission, $f_h$ = detuning at $T(f_h)=  0.7 T_{\min} + 0.3 T_{\max}$).
 
 Plot both model predictions against the data to provide visual evidence for your choice. Label the curves with their names and Akaike weights.
 

--- a/examples/axmodelfitter/ring_resonator/response.md
+++ b/examples/axmodelfitter/ring_resonator/response.md
@@ -59,3 +59,29 @@ The Lorentzian dip model fitted against all data:
 - **Execution Time:** 7.51s with nlopt optimizer
 
 **Physical Interpretation:** The ring resonator exhibits a classical Lorentzian line shape with a quality factor that can be estimated from the ratio of the resonance frequency to the linewidth. The fitted parameters indicate a high-quality resonator with ~17% transmission dip at resonance and a half-width of ~31 MHz.
+
+## 4. Uncertainty Quantification
+
+Parameter uncertainty was quantified using the parameter covariance matrix.
+
+### Robust covariance (Huber-White / sandwich)
+
+**Standard errors:**
+- T_max: 0.00196612 (dimensionless) (0.20% relative)
+- T_min: 0.00775136 (dimensionless) (0.93% relative)
+- f_h: 0.00161295 (GHz) (5.25% relative)
+
+**Correlation matrix:**
+
+| Parameter | T_max | T_min | f_h |
+|-----------|-------|-------|-----|
+| **T_max** | +1.000 | +0.050 | +0.542 |
+| **T_min** | +0.050 | +1.000 | +0.597 |
+| **f_h** | +0.542 | +0.597 | +1.000 |
+
+### Classical covariance (inverse Hessian)
+
+**Standard errors:**
+- T_max: 0.00212173 (dimensionless) (0.21% relative)
+- T_min: 0.00660559 (dimensionless) (0.79% relative)
+- f_h: 0.00204305 (GHz) (6.65% relative)


### PR DESCRIPTION
This PR adds an additional tool to compute the parameter covariance matrix to quantify uncertainty in the fitted parameters based on the `/digital-twin/compute-parameter-covariance` endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces uncertainty quantification to AxModelFitter.
> 
> - **New tool:** `compute_parameter_covariance` computes parameter covariance using robust Huber-White (sandwich) and inverse Hessian methods; returns covariance/correlation matrices and standard errors
> - **Service layer:** Added `CovarianceService` to call `/digital-twin/compute-parameter-covariance`, post-process results, and generate a markdown report
> - **Docs/examples:** README lists the new tool; ring modulator/resonator examples updated to include covariance analysis and results
> - **Minor changes:** Standardizes multi-line instruction strings across servers (`annotations`, `documents`, `equations`, `pic`, `plots`, shared utils/templates) without functional impact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3f86f8b78f6079759ac48abca8c0f102d42ffe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->