### PR TITLE
Add an MCP server for the argmin endpoints

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -26,7 +26,7 @@ make install-dev
     "args": ["-m", "axiomatic_mcp.servers.documents"],
     "env": {
       "AXIOMATIC_API_KEY": "your-api-key-here",
-      "API_URL": "https://api.staging.axiomatic-ai.com" // optionally point to staging/local environment
+      "AXIOMATIC_API_URL": "https://api.staging.axiomatic-ai.com" // optionally point to staging/local environment
     }
   }
 }
@@ -34,10 +34,11 @@ make install-dev
 
 ### Using staging or local environment
 
-In your MCP settings, change the `API_URL` parameter to point to the staging or local API (see configuration above):
+In your MCP settings, change the `AXIOMATIC_API_URL` parameter to point to the staging or local API (see configuration above):
 
-- staging: `"API_URL": "https://api.staging.axiomatic-ai.com"`
-- local: `"API_URL": "http://localhost:8000"` (or your chosen port to run ax-stack)
+- production (default): No `AXIOMATIC_API_URL` needed, uses `https://api.axiomatic-ai.com`
+- staging: `"AXIOMATIC_API_URL": "https://api.staging.axiomatic-ai.com"`
+- local: `"AXIOMATIC_API_URL": "http://localhost:8000"` (or your chosen port to run ax-stack)
 
 ### Adding a New Server
 

--- a/axiomatic_mcp/servers/__init__.py
+++ b/axiomatic_mcp/servers/__init__.py
@@ -5,6 +5,7 @@ from typing import TypedDict
 from fastmcp import FastMCP
 
 from .annotations.server import mcp as annotations_mcp
+from .argmin.server import mcp as argmin_mcp
 from .axmodelfitter.server import mcp as axmodelfitter_mcp
 from .documents.server import mcp as documents_mcp
 from .equations.server import mcp as equations_mcp
@@ -23,6 +24,7 @@ servers: list[ServerConfig] = [
     ServerConfig(domain="annotations", name="AxDocumentAnnotator", server=annotations_mcp),
     ServerConfig(domain="axmodelfitter", name="AxModelFitter", server=axmodelfitter_mcp),
     ServerConfig(domain="plots", name="AxPlotToData", server=plots_mcp),
+    ServerConfig(domain="argmin", name="AxArgmin", server=argmin_mcp),
 ]
 
 

--- a/axiomatic_mcp/servers/argmin/__init__.py
+++ b/axiomatic_mcp/servers/argmin/__init__.py
@@ -1,0 +1,5 @@
+def main():
+    """Main entry point for the AxArgmin server."""
+    from .server import mcp
+
+    mcp.run(transport="stdio")

--- a/axiomatic_mcp/servers/argmin/__main__.py
+++ b/axiomatic_mcp/servers/argmin/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/axiomatic_mcp/servers/argmin/server.py
+++ b/axiomatic_mcp/servers/argmin/server.py
@@ -1,0 +1,109 @@
+from typing import Annotated
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.tools.tool import ToolResult
+from mcp.types import TextContent
+
+from ...providers.middleware_provider import get_mcp_middleware
+from ...providers.toolset_provider import get_mcp_tools
+from ...shared.utils.prompt_utils import get_feedback_prompt
+from .services.argmin_service import ArgminService
+
+mcp = FastMCP(
+    name="AxArgmin Server",
+    instructions="""This server provides tools for numerical optimization, rootfinding, ODE simulation, and optimal control
+    using the argmin library. Use generate_code to produce executable code from a problem description,
+    then execute_code to run it in a sandboxed environment.
+    """
+    + get_feedback_prompt(["generate_code", "execute_code"]),
+    version="0.0.1",
+    middleware=get_mcp_middleware(),
+    tools=get_mcp_tools(),
+)
+
+argmin_service = ArgminService()
+
+
+@mcp.tool(
+    name="generate_code",
+    description=(
+        "Generate Python code to solve a numerical problem using the argmin library. "
+        "Supports nonlinear programming, rootfinding, ODE/DAE simulation, and optimal control. "
+        "Returns executable code and an explanation of the approach. "
+        "The code must be executed separately using the execute_code tool."
+    ),
+    tags=["argmin", "optimization", "code-generation"],
+)
+async def generate_code(
+    problem_description: Annotated[str, "Natural language or mathematical description of the problem"],
+    problem_type: Annotated[
+        str,
+        "Problem type: 'nonlinear_program' (minimize f(x) s.t. constraints), "
+        "'nonlinear_equations' (solve F(x)=0, rootfinding), "
+        "'initial_value_problem' (integrate dx/dt=f(x,t), ODE/DAE), "
+        "or 'optimal_control' (dynamic optimization over time)",
+    ],
+) -> ToolResult:
+    """Generate Python code for a numerical problem using the argmin library."""
+    valid_types = {"nonlinear_program", "nonlinear_equations", "initial_value_problem", "optimal_control"}
+    if problem_type not in valid_types:
+        raise ToolError(f"Invalid problem_type '{problem_type}'. Must be one of: {', '.join(sorted(valid_types))}")
+
+    try:
+        response = argmin_service.generate_code(problem_description, problem_type)
+    except Exception as e:
+        raise ToolError(f"Failed to generate code: {e!s}") from e
+
+    if response.get("error"):
+        return ToolResult(content=[TextContent(type="text", text=f"Code generation failed: {response['error']}")])
+
+    content = []
+    if response.get("explanation"):
+        content.append(TextContent(type="text", text=response["explanation"]))
+    if response.get("code"):
+        content.append(TextContent(type="text", text=f"```python\n{response['code']}\n```"))
+
+    return ToolResult(
+        content=content,
+        structured_content=response,
+    )
+
+
+@mcp.tool(
+    name="execute_code",
+    description=(
+        "Execute Python code in a sandboxed environment with numpy, math, and the ax_core.argmin "
+        "numerical library available. Code must call export(name, value) at least once to return results. "
+        "Typically used to run code produced by the generate_code tool, but also accepts hand-written or modified code."
+    ),
+    tags=["argmin", "execution", "sandbox"],
+)
+async def execute_code(
+    code: Annotated[str, "Python code to execute. Must call export(name, value) to return results."],
+) -> ToolResult:
+    """Execute Python code in the argmin sandbox."""
+    try:
+        response = argmin_service.execute_code(code)
+    except Exception as e:
+        raise ToolError(f"Failed to execute code: {e!s}") from e
+
+    if not response.get("success"):
+        error_msg = response.get("error", "Unknown execution error")
+        stdout = response.get("stdout", "")
+        text = f"Execution failed: {error_msg}"
+        if stdout:
+            text += f"\n\nStdout:\n{stdout}"
+        return ToolResult(content=[TextContent(type="text", text=text)])
+
+    parts = []
+    if response.get("result"):
+        parts.append(TextContent(type="text", text=f"Result: {response['result']}"))
+    if response.get("stdout"):
+        parts.append(TextContent(type="text", text=f"Stdout:\n{response['stdout']}"))
+    parts.append(TextContent(type="text", text=f"Execution time: {response.get('execution_time', 0):.3f}s"))
+
+    return ToolResult(
+        content=parts,
+        structured_content=response,
+    )

--- a/axiomatic_mcp/servers/argmin/server.py
+++ b/axiomatic_mcp/servers/argmin/server.py
@@ -15,8 +15,7 @@ mcp = FastMCP(
     instructions="""This server provides tools for numerical optimization, rootfinding, ODE simulation, and optimal control
     using the argmin library. Use generate_code to produce executable code from a problem description,
     then execute_code to run it in a sandboxed environment.
-    """
-    + get_feedback_prompt(["generate_code", "execute_code"]),
+    """ + get_feedback_prompt(["generate_code", "execute_code"]),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),

--- a/axiomatic_mcp/servers/argmin/services/argmin_service.py
+++ b/axiomatic_mcp/servers/argmin/services/argmin_service.py
@@ -1,0 +1,47 @@
+"""Service for argmin numerical optimization API calls."""
+
+from typing import Any
+
+from ....shared import AxiomaticAPIClient
+from ....shared.constants.api_constants import ApiRoutes
+from ....shared.models.singleton_base import SingletonBase
+
+
+class ArgminService(SingletonBase):
+    """Thin proxy service for argmin code generation and execution endpoints."""
+
+    def generate_code(self, problem_description: str, problem_type: str) -> dict[str, Any]:
+        """
+        Generate Python code for a numerical problem.
+
+        Args:
+            problem_description: Natural language or mathematical description of the problem.
+            problem_type: One of nonlinear_program, nonlinear_equations, initial_value_problem, optimal_control.
+
+        Returns:
+            dict with keys: code, explanation, error
+        """
+        with AxiomaticAPIClient() as client:
+            return client.post(
+                ApiRoutes.ARGMIN_WRITE_CODE,
+                data={
+                    "problem_description": problem_description,
+                    "problem_type": problem_type,
+                },
+            )
+
+    def execute_code(self, code: str) -> dict[str, Any]:
+        """
+        Execute Python code in the argmin sandbox.
+
+        Args:
+            code: Python code to execute. Must call export(name, value).
+
+        Returns:
+            dict with keys: success, result, error, stdout, execution_time
+        """
+        with AxiomaticAPIClient() as client:
+            return client.post(
+                ApiRoutes.ARGMIN_EXECUTE,
+                data={"code": code},
+            )

--- a/axiomatic_mcp/shared/api_client.py
+++ b/axiomatic_mcp/shared/api_client.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import httpx
 
-API_URL = os.getenv("API_URL", "https://api.axiomatic-ai.com")
+API_URL = os.getenv("API_URL", "https://api.staging.axiomatic-ai.com")
 
 TIMEOUT = 1000
 

--- a/axiomatic_mcp/shared/api_client.py
+++ b/axiomatic_mcp/shared/api_client.py
@@ -3,19 +3,24 @@ from typing import Any
 
 import httpx
 
-API_URL = os.getenv("API_URL", "https://api.staging.axiomatic-ai.com")
+# Default to production for PyPI package
+DEFAULT_API_URL = "https://api.axiomatic-ai.com"
 
 TIMEOUT = 1000
 
 
 class AxiomaticAPIClient:
     def __init__(self):
+        # Get API URL
+        api_url = os.getenv("AXIOMATIC_API_URL", DEFAULT_API_URL)
+
+        # Get API Key
         api_key = os.getenv("AXIOMATIC_API_KEY")
         if not api_key:
             raise ValueError("AXIOMATIC_API_KEY environment variable is not set")
 
         self.client = httpx.Client(
-            base_url=API_URL,
+            base_url=api_url,
             timeout=TIMEOUT,
             headers={
                 "X-API-Key": api_key,

--- a/axiomatic_mcp/shared/constants/api_constants.py
+++ b/axiomatic_mcp/shared/constants/api_constants.py
@@ -15,7 +15,5 @@ class ApiRoutes:
     PDK_PERMISSION = "/users/pdk-permissions/me"
     PDK_INFO = "/pic/pdk/{pdk_type}/info"
     MCP_MODEL_FEEDBACK = "/mcp/model-feedback"
-
-    # Argmin endpoints
     ARGMIN_WRITE_CODE = "/numerics/argmin/write-code"
     ARGMIN_EXECUTE = "/numerics/argmin/execute"

--- a/axiomatic_mcp/shared/constants/api_constants.py
+++ b/axiomatic_mcp/shared/constants/api_constants.py
@@ -15,3 +15,7 @@ class ApiRoutes:
     PDK_PERMISSION = "/users/pdk-permissions/me"
     PDK_INFO = "/pic/pdk/{pdk_type}/info"
     MCP_MODEL_FEEDBACK = "/mcp/model-feedback"
+
+    # Argmin endpoints
+    ARGMIN_WRITE_CODE = "/numerics/argmin/write-code"
+    ARGMIN_EXECUTE = "/numerics/argmin/execute"

--- a/examples/argmin/README.md
+++ b/examples/argmin/README.md
@@ -1,0 +1,10 @@
+# Argmin Examples
+
+Examples for the `AxArgmin` MCP server.
+
+Each folder contains:
+- `prompt.md` — what to ask the agent
+
+## Usage
+
+Give the agent the prompt — it will call `generate_code` then `execute_code` to solve the problem.

--- a/examples/argmin/chemical_equilibrium/prompt.md
+++ b/examples/argmin/chemical_equilibrium/prompt.md
@@ -1,0 +1,3 @@
+# Chemical Equilibrium
+
+Find the equilibrium composition for a gas-phase system with 3 coupled reactions and 5 species (A, B, C, D, E). The reactions and equilibrium constants are: (1) A + B <-> C, K1 = 10, (2) C + B <-> D, K2 = 5, (3) 2A <-> E, K3 = 2. The equilibrium conditions are: K1 = [C]/([A]*[B]), K2 = [D]/([C]*[B]), K3 = [E]/[A]^2. The element balances (conservation of mass) with initial moles A0=2.0, B0=2.0, C0=0, D0=0, E0=0 in a volume V=1 are: A0 = [A] + [C] + [D] + 2*[E] (element balance for A-atoms), B0 = [B] + [C] + 2*[D] (element balance for B-atoms). Solve the 5 equations (3 equilibrium + 2 element balances) for the 5 unknown concentrations [A],[B],[C],[D],[E]. All concentrations must be positive. Use initial guesses around 0.5 for all species.

--- a/examples/argmin/clamped_beam/prompt.md
+++ b/examples/argmin/clamped_beam/prompt.md
@@ -1,0 +1,20 @@
+# Clamped Beam (Optimal Control)
+
+Minimize control effort to deflect a clamped beam while keeping deflection within bounds.
+
+Use a simple single-mode surrogate for the beam tip deflection:
+
+- **States:** tip deflection `w(t)` and velocity `v(t)`
+- **Control:** actuator force `u(t)`
+- **Dynamics:**
+  - `w_dot = v`
+  - `v_dot = u`
+
+Solve a minimum-energy deflection maneuver:
+
+- **Time horizon:** `T = 1.0`
+- **Initial state:** `w(0) = 0`, `v(0) = 0`
+- **Terminal state:** `w(T) = 0.1`, `v(T) = 0`
+- **State bounds:** `-0.12 <= w(t) <= 0.12`
+- **Control bounds:** `-2.0 <= u(t) <= 2.0`
+- **Objective:** minimize control effort `∫ u(t)^2 dt`

--- a/examples/argmin/lorenz_attractor/prompt.md
+++ b/examples/argmin/lorenz_attractor/prompt.md
@@ -1,0 +1,4 @@
+# Lorenz Attractor
+
+Simulate the Lorenz system for 25 s with classic chaotic parameters (σ=10, ρ=28, β=8/3).
+Initial state: (1, 1, 1).

--- a/examples/argmin/sensor_placement/prompt.md
+++ b/examples/argmin/sensor_placement/prompt.md
@@ -1,0 +1,4 @@
+# Optimal Sensor Placement
+
+Place 3 sensors in a 10×10 region to maximize the minimum pairwise distance.
+Each sensor must be at least 2 units from every boundary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ axiomatic-plots = "axiomatic_mcp.servers.plots:main"
 axiomatic-equations = "axiomatic_mcp.servers.equations:main"
 axiomatic-axmodelfitter = "axiomatic_mcp.servers.axmodelfitter:main"
 axiomatic-annotations = "axiomatic_mcp.servers.annotations:main"
+axiomatic-argmin = "axiomatic_mcp.servers.argmin:main"
 all = "axiomatic_mcp:main"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
We wrap the Axiomatic argmin API endpoints into an MCP server so that any LLM agent can use numerical optimization, rootfinding, ODE simulation, and optimal control as tools. 

Tools:
`generate_code`: `POST /numerics/argmin/write-code` 
`execute_code`: `POST /numerics/argmin/execute`

Note: For testing this, I've set the API_URL to "https://api.staging.axiomatic-ai.com". We should revert before merging, when the endpoints are in production. 