### PR TITLE
Fixture and client bugs

### DIFF
--- a/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
+++ b/axiomatic_mcp/servers/axmodelfitter/services/covariance_service.py
@@ -1,5 +1,6 @@
 """Service for computing parameter covariance matrices."""
 
+import atexit
 import json
 
 import httpx
@@ -17,9 +18,19 @@ class CovarianceService(SingletonBase):
     classical inverse Hessian approach.
     """
     def __init__(self):
-        if hasattr(self, '_client'):
+        if getattr(self, "_client", None) is not None:
             return
         self._client = AxiomaticAPIClient()
+        atexit.register(self.close)
+
+    def close(self) -> None:
+        """Close underlying HTTP client used by this singleton."""
+        if getattr(self, "_client", None) is not None:
+            self._client.client.close()
+            self._client = None
+
+    def __del__(self):
+        self.close()
 
     async def compute_covariance(self, request_data: dict) -> dict:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,7 +286,7 @@ def simple_response_parameter_covariance():
 
 @pytest.fixture
 def linear_response_parameter_covariance():
-    {
+    return {
     "param_names": [
         "a",
         "b"
@@ -314,6 +314,7 @@ def linear_response_parameter_covariance():
     "scale_params": "false"
     }
 
+@pytest.fixture
 def nonlinear_response_parameter_covariance():
     return {
     "param_names": [


### PR DESCRIPTION
Fixes pytest fixture (currently unused) definitions and addresses an `httpx.Client` connection leak in the `CovarianceService`.