### PR TITLE
data inlining effort

### DIFF
--- a/axiomatic_mcp/servers/modelfitter/data_inlining.py
+++ b/axiomatic_mcp/servers/modelfitter/data_inlining.py
@@ -1,0 +1,125 @@
+"""Load a local CSV/JSON file and inline it as a numpy-only preamble.
+
+The v2 sandbox runs in-process exec() behind an import whitelist that allows
+numpy but NOT pandas/io/json. pandas is used HERE (MCP-side, on the user's
+machine) only to read the file; the emitted preamble imports numpy only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+SUPPORTED_EXTENSIONS = {".csv", ".json"}
+
+# Soft cap on the generated preamble string. Large data is not supported in
+# this inline path (see the spec's roadmap: Phase 2/3).
+DEFAULT_MAX_PREAMBLE_BYTES = 5 * 1024 * 1024
+
+
+class DataInliningError(Exception):
+    """Raised when a local data file cannot be loaded or inlined."""
+
+
+def load_table(path: str) -> pd.DataFrame:
+    """Load a local .csv or .json file into a DataFrame.
+
+    JSON must be tabular (records list, or {column: [values]}).
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise DataInliningError(f"Data file not found: {path}")
+
+    ext = p.suffix.lower()
+    if ext not in SUPPORTED_EXTENSIONS:
+        raise DataInliningError(f"Unsupported data file type '{ext}'. Supported: {sorted(SUPPORTED_EXTENSIONS)}")
+
+    try:
+        df = pd.read_csv(p) if ext == ".csv" else pd.read_json(p)
+    except Exception as e:
+        raise DataInliningError(f"Failed to read {path}: {e}") from e
+
+    if df.empty:
+        raise DataInliningError(f"Data file is empty: {path}")
+
+    return df
+
+
+def preview_table(path: str, n_rows: int = 20) -> dict:
+    """Return a lightweight schema preview: column names, dtypes, and the first
+    n_rows as records. CSV reads only the head (nrows); JSON is read in full.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise DataInliningError(f"Data file not found: {path}")
+
+    ext = p.suffix.lower()
+    if ext not in SUPPORTED_EXTENSIONS:
+        raise DataInliningError(f"Unsupported data file type '{ext}'. Supported: {sorted(SUPPORTED_EXTENSIONS)}")
+
+    try:
+        df = pd.read_csv(p, nrows=n_rows) if ext == ".csv" else pd.read_json(p).head(n_rows)
+    except Exception as e:
+        raise DataInliningError(f"Failed to read {path}: {e}") from e
+
+    return {
+        "columns": list(df.columns),
+        "dtypes": {c: str(df[c].dtype) for c in df.columns},
+        "sample": df.to_dict(orient="records"),
+    }
+
+
+def build_preamble(
+    df: pd.DataFrame,
+    columns: list[str] | None = None,
+    max_bytes: int = DEFAULT_MAX_PREAMBLE_BYTES,
+) -> str:
+    """Build a numpy-only preamble defining `data` as a dict of
+    column-name -> 1-D float np.array.
+
+    Validation is aggregated: every unusable column (missing / non-numeric /
+    non-finite) is collected and reported in a single DataInliningError, rather
+    than failing one column at a time. Also raises if nothing is selected or the
+    preamble exceeds max_bytes.
+    """
+    selected = list(df.columns) if columns is None else columns
+    if not selected:
+        raise DataInliningError("No columns selected to inline.")
+
+    problems: list[str] = []
+    entries: list[str] = []
+
+    for col in selected:
+        if col not in df.columns:
+            problems.append(f"'{col}': not found")
+            continue
+        try:
+            values = df[col].astype(float).to_numpy()
+        except (ValueError, TypeError):
+            problems.append(f"'{col}': not numeric ({df[col].dtype})")
+            continue
+        if not np.isfinite(values).all():
+            problems.append(f"'{col}': contains NaN/inf")
+            continue
+        literal = ", ".join(repr(float(v)) for v in values)
+        entries.append(f"    {col!r}: np.array([{literal}]),")
+
+    if problems:
+        raise DataInliningError(
+            "Cannot inline column(s): "
+            + "; ".join(problems)
+            + f". Available columns: {list(df.columns)}. "
+            + "Pass `columns=[...]` to inline a usable subset."
+        )
+
+    preamble = "import numpy as np\ndata = {\n" + "\n".join(entries) + "\n}\n"
+
+    size = len(preamble.encode("utf-8"))
+    if size > max_bytes:
+        raise DataInliningError(
+            f"Inlined data ({size} bytes) exceeds the {max_bytes}-byte cap for inline execution. "
+            f"Reduce rows/columns; large data is not supported in this path yet."
+        )
+    return preamble

--- a/axiomatic_mcp/servers/modelfitter/server.py
+++ b/axiomatic_mcp/servers/modelfitter/server.py
@@ -10,6 +10,7 @@ from mcp.types import TextContent
 from ...providers.middleware_provider import get_mcp_middleware
 from ...providers.toolset_provider import get_mcp_tools
 from ...shared.utils.prompt_utils import get_feedback_prompt
+from .data_inlining import DataInliningError, preview_table
 from .services.model_fitter_service import ModelFitterService
 
 mcp = FastMCP(
@@ -66,16 +67,30 @@ async def generate_code(
         "Execute Python code in a sandboxed environment with JAX (jnp), diffrax, equinox, "
         "and the ax_core.model_fitter library available. Code must call export(name, value) "
         "at least once to return results. Typically used to run code produced by generate_code, "
-        "but also accepts hand-written or modified code."
+        "but also accepts hand-written or modified code.\n\n"
+        "Optionally pass data_file (a local .csv or .json path) to inline tabular data: the "
+        "server reads it locally and injects `data`, a dict mapping each column name to a 1-D "
+        "numpy float array (access as data['col']). Use `columns` to inline only a subset; call "
+        "preview_data first to see the available columns. Intended for small datasets."
     ),
     tags=["model-fitter", "execution", "sandbox"],
 )
 async def execute_code(
     code: Annotated[str, "Python code to execute. Must call export(name, value) to return results."],
+    data_file: Annotated[
+        str | None,
+        "Optional local .csv/.json path. Columns are inlined as a numpy dict `data` (data['col']).",
+    ] = None,
+    columns: Annotated[
+        list[str] | None,
+        "Optional subset of columns to inline (default: all columns).",
+    ] = None,
 ) -> ToolResult:
     """Execute Python fitting code in the model fitter sandbox."""
     try:
-        response = model_fitter_service.execute_code(code)
+        response = model_fitter_service.execute_code(code, data_file=data_file, columns=columns)
+    except DataInliningError as e:
+        raise ToolError(f"Data file error: {e!s}") from e
     except Exception as e:
         raise ToolError(f"Failed to execute code: {e!s}") from e
 
@@ -95,6 +110,33 @@ async def execute_code(
     parts.append(TextContent(type="text", text=f"Execution time: {response.get('execution_time', 0):.3f}s"))
 
     return ToolResult(content=parts, structured_content=response)
+
+
+@mcp.tool(
+    name="preview_data",
+    description=(
+        "Preview a local .csv or .json data file before fitting: returns its column "
+        "names, per-column dtypes, and the first n_rows as sample records. Use this to "
+        "decide which columns to pass as `columns` to execute_code. Reads only the head "
+        "of the file, so it is cheap on large files."
+    ),
+    tags=["model-fitter", "data", "preview"],
+)
+async def preview_data(
+    data_file: Annotated[str, "Local .csv or .json path to preview."],
+    n_rows: Annotated[int, "Number of sample rows to return (default 20)."] = 20,
+) -> ToolResult:
+    """Return schema + head for a local data file."""
+    try:
+        info = preview_table(data_file, n_rows=n_rows)
+    except DataInliningError as e:
+        raise ToolError(f"Data file error: {e!s}") from e
+
+    summary = "Columns: " + ", ".join(f"{c} ({info['dtypes'][c]})" for c in info["columns"])
+    return ToolResult(
+        content=[TextContent(type="text", text=summary)],
+        structured_content=info,
+    )
 
 
 def main():

--- a/axiomatic_mcp/servers/modelfitter/services/model_fitter_service.py
+++ b/axiomatic_mcp/servers/modelfitter/services/model_fitter_service.py
@@ -5,6 +5,7 @@ from typing import Any
 from ....shared import AxiomaticAPIClient
 from ....shared.constants.api_constants import ApiRoutes
 from ....shared.models.singleton_base import SingletonBase
+from ..data_inlining import build_preamble, load_table
 
 
 class ModelFitterService(SingletonBase):
@@ -17,7 +18,14 @@ class ModelFitterService(SingletonBase):
                 data={"problem_description": problem_description},
             )
 
-    def execute_code(self, code: str) -> dict[str, Any]:
+    def execute_code(
+        self,
+        code: str,
+        data_file: str | None = None,
+        columns: list[str] | None = None,
+    ) -> dict[str, Any]:
+        if data_file is not None:
+            code = build_preamble(load_table(data_file), columns) + "\n" + code
         with AxiomaticAPIClient() as client:
             return client.post(
                 ApiRoutes.MODEL_FITTER_EXECUTE,

--- a/tests/servers/modelfitter/data_inlining_test.py
+++ b/tests/servers/modelfitter/data_inlining_test.py
@@ -1,0 +1,184 @@
+"""Unit tests for model_fitter local-data inlining."""
+
+import json
+from typing import ClassVar
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from axiomatic_mcp.servers.modelfitter.data_inlining import (
+    DataInliningError,
+    build_preamble,
+    load_table,
+    preview_table,
+)
+from axiomatic_mcp.servers.modelfitter.services.model_fitter_service import (
+    ModelFitterService,
+)
+
+_SVC_CLIENT = "axiomatic_mcp.servers.modelfitter.services.model_fitter_service.AxiomaticAPIClient"
+
+
+def _exec_preamble(preamble: str) -> dict:
+    ns: dict = {}
+    # exercise the generated preamble exactly as the sandbox does (in-process exec)
+    exec(preamble, ns)
+    return ns["data"]
+
+
+class _CaptureClient:
+    """Stand-in AxiomaticAPIClient that records the posted code instead of calling the API."""
+
+    captured: ClassVar[dict] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def post(self, route, data=None):
+        _CaptureClient.captured["code"] = data["code"]
+        return {"success": True, "result": {}}
+
+
+# CSV loads into a DataFrame with the expected columns and values.
+def test_load_csv(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t,y\n0.0,1.0\n1.0,2.5\n")
+    df = load_table(str(p))
+    assert list(df.columns) == ["t", "y"]
+    assert df["y"].tolist() == [1.0, 2.5]
+
+
+# A records-style JSON array loads into a tabular DataFrame.
+def test_load_json_records(tmp_path):
+    p = tmp_path / "d.json"
+    p.write_text(json.dumps([{"t": 0.0, "y": 1.0}, {"t": 1.0, "y": 2.5}]))
+    df = load_table(str(p))
+    assert df["t"].tolist() == [0.0, 1.0]
+
+
+# A nonexistent path is reported clearly.
+def test_load_missing_file_raises():
+    with pytest.raises(DataInliningError, match="not found"):
+        load_table("/no/such/file.csv")
+
+
+# Unsupported extensions are rejected before any read attempt.
+def test_load_unsupported_extension_raises(tmp_path):
+    p = tmp_path / "d.parquet"
+    p.write_text("x")
+    with pytest.raises(DataInliningError, match="Unsupported"):
+        load_table(str(p))
+
+
+# A header-only CSV (no rows) is treated as empty.
+def test_load_empty_csv_raises(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t,y\n")
+    with pytest.raises(DataInliningError, match="empty"):
+        load_table(str(p))
+
+
+# The preamble defines `data` as a dict of column -> numpy array.
+def test_build_preamble_defines_data_dict():
+    df = pd.DataFrame({"t": [0.0, 1.0], "y": [1.0, 2.5]})
+    data = _exec_preamble(build_preamble(df))
+    assert set(data.keys()) == {"t", "y"}
+    assert isinstance(data["t"], np.ndarray)
+    assert data["y"].tolist() == [1.0, 2.5]
+
+
+# Float values round-trip through the literal without precision loss.
+def test_build_preamble_preserves_precision():
+    df = pd.DataFrame({"x": [0.1234567890123456, 9.876543210987654]})
+    data = _exec_preamble(build_preamble(df))
+    assert data["x"].tolist() == [0.1234567890123456, 9.876543210987654]
+
+
+# Explicit columns select only the requested subset.
+def test_build_preamble_column_subset():
+    df = pd.DataFrame({"t": [0.0], "y": [1.0], "z": [2.0]})
+    data = _exec_preamble(build_preamble(df, columns=["t", "z"]))
+    assert set(data.keys()) == {"t", "z"}
+
+
+# An unknown explicit column is reported as not found.
+def test_build_preamble_unknown_column_raises():
+    df = pd.DataFrame({"t": [0.0]})
+    with pytest.raises(DataInliningError, match="not found"):
+        build_preamble(df, columns=["nope"])
+
+
+# A non-numeric column cannot be coerced to float.
+def test_build_preamble_non_numeric_raises():
+    df = pd.DataFrame({"label": ["a", "b"]})
+    with pytest.raises(DataInliningError, match="not numeric"):
+        build_preamble(df)
+
+
+# NaN/inf values are rejected rather than emitted as invalid literals.
+def test_build_preamble_non_finite_raises():
+    df = pd.DataFrame({"y": [1.0, float("nan")]})
+    with pytest.raises(DataInliningError, match="NaN/inf"):
+        build_preamble(df)
+
+
+# A preamble larger than the cap is refused.
+def test_build_preamble_size_cap_raises():
+    df = pd.DataFrame({"y": [1.0, 2.0, 3.0]})
+    with pytest.raises(DataInliningError, match="exceeds"):
+        build_preamble(df, max_bytes=10)
+
+
+# Every bad column is reported in a single error, not one at a time.
+def test_build_preamble_aggregates_all_problems():
+    df = pd.DataFrame({"t": [1.0], "label": ["a"], "bad": [float("inf")]})
+    with pytest.raises(DataInliningError) as exc:
+        build_preamble(df)
+    msg = str(exc.value)
+    assert "label" in msg and "bad" in msg
+
+
+# preview_table returns column names, dtypes, and a head sample.
+def test_preview_table_returns_schema_and_sample(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t,temp,note\n0.0,1.0,a\n1.0,2.0,b\n2.0,3.0,c\n")
+    info = preview_table(str(p), n_rows=2)
+    assert info["columns"] == ["t", "temp", "note"]
+    assert set(info["dtypes"]) == {"t", "temp", "note"}
+    assert info["dtypes"]["note"] == "object"
+    assert len(info["sample"]) == 2
+    assert info["sample"][0]["t"] == 0.0
+
+
+# preview_table rejects unsupported extensions like load_table does.
+def test_preview_table_unsupported_extension_raises(tmp_path):
+    p = tmp_path / "d.parquet"
+    p.write_text("x")
+    with pytest.raises(DataInliningError, match="Unsupported"):
+        preview_table(str(p))
+
+
+# With a data_file, the service prepends the numpy preamble to the code.
+def test_service_prepends_preamble(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t,y\n0.0,1.0\n1.0,2.5\n")
+    _CaptureClient.captured = {}
+    with patch(_SVC_CLIENT, _CaptureClient):
+        ModelFitterService().execute_code("export('ok', 1)", data_file=str(p))
+    code = _CaptureClient.captured["code"]
+    assert "import numpy as np" in code
+    assert "data = {" in code
+    assert "export('ok', 1)" in code
+
+
+# Without a data_file, the code is sent through unchanged.
+def test_service_no_data_file_sends_code_unchanged():
+    _CaptureClient.captured = {}
+    with patch(_SVC_CLIENT, _CaptureClient):
+        ModelFitterService().execute_code("export('ok', 1)")
+    assert _CaptureClient.captured["code"] == "export('ok', 1)"

--- a/tests/servers/modelfitter/server_test.py
+++ b/tests/servers/modelfitter/server_test.py
@@ -1,8 +1,9 @@
 """Tests for the AxModelFitterV2 MCP server."""
 
+from unittest.mock import patch
+
 import pytest
 import pytest_asyncio
-from unittest.mock import patch
 from fastmcp.client import Client
 
 from axiomatic_mcp.servers.modelfitter.server import mcp
@@ -48,3 +49,63 @@ async def test_execute_code_failure(mcp_client):
     texts = [c.text for c in response.content if hasattr(c, "text")]
     assert any("NameError" in t for t in texts)
     assert any("Traceback" in t for t in texts)
+
+
+# execute_code forwards a data_file through to the service.
+@pytest.mark.asyncio
+async def test_execute_code_accepts_data_file(mcp_client, tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t,y\n0.0,1.0\n1.0,2.5\n")
+    captured = {}
+
+    def _fake_execute(self, code, data_file=None, columns=None):
+        captured["data_file"] = data_file
+        return {"success": True, "result": {"ok": 1}, "stdout": None, "execution_time": 0.0}
+
+    with patch.object(ModelFitterService, "execute_code", _fake_execute):
+        response = await mcp_client.call_tool(
+            "execute_code",
+            {"code": "export('ok', 1)", "data_file": str(p)},
+        )
+
+    assert captured["data_file"] == str(p)
+    assert any("ok" in c.text for c in response.content if hasattr(c, "text"))
+
+
+# A data-inlining failure surfaces as a ToolError, before any API call.
+@pytest.mark.asyncio
+async def test_execute_code_data_file_error_is_toolerror(mcp_client):
+    from fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError, match="Data file error"):
+        await mcp_client.call_tool(
+            "execute_code",
+            {"code": "export('ok', 1)", "data_file": "/no/such/file.csv"},
+        )
+
+
+# preview_data returns the file's columns so the agent can choose what to inline.
+@pytest.mark.asyncio
+async def test_preview_data_returns_columns(mcp_client, tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t,temp,note\n0.0,1.0,a\n1.0,2.0,b\n")
+    response = await mcp_client.call_tool("preview_data", {"data_file": str(p)})
+    texts = [c.text for c in response.content if hasattr(c, "text")]
+    assert any("temp" in t for t in texts)
+
+
+# preview_data maps a bad path to a ToolError.
+@pytest.mark.asyncio
+async def test_preview_data_error_is_toolerror(mcp_client):
+    from fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError, match="Data file error"):
+        await mcp_client.call_tool("preview_data", {"data_file": "/no/such/file.csv"})
+
+
+# The server exposes exactly the three expected tools.
+@pytest.mark.asyncio
+async def test_list_tools_includes_preview(mcp_client):
+    tools = await mcp_client.list_tools()
+    names = {t.name for t in tools}
+    assert {"generate_code", "execute_code", "preview_data"} <= names


### PR DESCRIPTION
Allows quick data inlining from .csv files and .json files, specifically columnar data. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the execute path by reading local file paths and sending larger concatenated code to the remote executor; validation limits abuse but path handling and payload size warrant review.
> 
> **Overview**
> Adds **local tabular data inlining** for the Model Fitter v2 MCP server so fitting code can use a `data` dict without pandas in the sandbox.
> 
> A new `data_inlining` module reads **`.csv` / `.json`** on the MCP host (pandas), validates columns (numeric, finite, optional subset), and emits a **numpy-only preamble** that defines `data['col']` as 1-D float arrays, with a **~5MB** size cap and aggregated validation errors.
> 
> **`execute_code`** gains optional `data_file` and `columns`; the service **prepends** that preamble to user code before posting to the existing execute API. **`preview_data`** is a new tool for column names, dtypes, and a small sample (cheap head read for CSV). Data errors map to **`ToolError`** before execution.
> 
> Unit and server tests cover loading, preamble behavior, service prepending, and MCP wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6338f75092f9221896a74ac00e711cae0bcb2057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->