### PR TITLE
Fix equation tools for external users + drop V2 model-fitter branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,13 +249,13 @@ Design photonic integrated circuits using natural language descriptions. Additio
 
 Extract numerical data from plot images for analysis and reproduction.
 
-### ⚙️ [AxModelFitter](https://github.com/Axiomatic-AI/ax-mcp/tree/main/axiomatic_mcp/servers/axmodelfitter/) (LEGACY)
+### ⚙️ [AxModelFitter](https://github.com/Axiomatic-AI/ax-mcp/tree/main/axiomatic_mcp/servers/modelfitter/)
 
-Fit parametric models or digital twins to observational data using advanced statistical analysis and optimization algorithms.
+Fit parametric models or digital twins to observational data. Describe the model and data in plain language — the server generates executable JAX fitting code and runs it in a sandboxed environment.
 
-### ⚙️ [AxModelFitterv2](https://github.com/Axiomatic-AI/ax-mcp/tree/main/axiomatic_mcp/servers/modelfitter/)
+### ⚙️ [AxModelFitter (Legacy)](https://github.com/Axiomatic-AI/ax-mcp/tree/main/axiomatic_mcp/servers/axmodelfitter/)
 
-Fit parametric models or digital twins to observational data using advanced statistical analysis and optimization algorithms.
+Deprecated — superseded by AxModelFitter above; will be removed in the next major release.
 
 ## Requesting Features
 

--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Axiomatic MCP Servers - Modular MCP servers built with FastMCP."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.17"
 
 import asyncio
 

--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -11,7 +11,11 @@ from .servers import servers
 
 axiomatic_mcp = FastMCP(
     name="Axiomatic MCP",
-    instructions="""This server provides various tools to help with physics and engineering workflows..""",
+    instructions="""This server provides various tools to help with physics and engineering workflows.
+
+    For model fitting: use the AxModelFitter_* tools for new workflows. The AxModelFitterLegacy_* tools are the
+    deprecated continuation of the original AxModelFitter toolset — existing workflows built on them should keep
+    using them this release; they will be removed in the next major release.""",
     version=__version__,
     middleware=get_mcp_middleware(),
 )

--- a/axiomatic_mcp/servers/__init__.py
+++ b/axiomatic_mcp/servers/__init__.py
@@ -23,10 +23,10 @@ servers: list[ServerConfig] = [
     ServerConfig(domain="equations", name="AxEquationExplorer", server=equations_mcp),
     ServerConfig(domain="documents", name="AxDocumentParser", server=documents_mcp),
     ServerConfig(domain="annotations", name="AxDocumentAnnotator", server=annotations_mcp),
-    ServerConfig(domain="axmodelfitter", name="AxModelFitter", server=axmodelfitter_mcp),
+    ServerConfig(domain="axmodelfitter", name="AxModelFitterLegacy", server=axmodelfitter_mcp),
     ServerConfig(domain="plots", name="AxPlotToData", server=plots_mcp),
     ServerConfig(domain="argmin", name="AxArgmin", server=argmin_mcp),
-    ServerConfig(domain="modelfitter", name="AxModelFitterV2", server=modelfitter_mcp),
+    ServerConfig(domain="modelfitter", name="AxModelFitter", server=modelfitter_mcp),
 ]
 
 

--- a/axiomatic_mcp/servers/axmodelfitter/README.md
+++ b/axiomatic_mcp/servers/axmodelfitter/README.md
@@ -1,8 +1,7 @@
 # AxModelFitter (Legacy)
 
-> **Legacy:** This server is superseded by `axiomatic-modelfitter`. It will be removed in a future release.
-
-# AxModelFitter
+> **DEPRECATED:** This server is deprecated and will be removed in the next major release.
+> Use the new [AxModelFitter](../modelfitter/README.md) server instead — console script `axiomatic-modelfitter`, config key `"axiomatic-modelfitter"`.
 
 An MCP server for fitting mathematical models to experimental data using the Axiomatic AI platform's optimization algorithms.
 

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -377,8 +377,10 @@ def evaluate_model(payload: dict) -> dict:
 
 
 mcp = FastMCP(
-    name="AxModelFitter Server",
-    instructions="""This server provides mathematical model fitting capabilities using the Axiomatic AI platform.
+    name="AxModelFitter Legacy Server",
+    instructions="""DEPRECATED: This legacy server will be removed in the next major release. Prefer the new AxModelFitter server (console script `axiomatic-modelfitter`), which generates and executes fitting code directly.
+
+    This server provides mathematical model fitting capabilities using the Axiomatic AI platform.
 
     Fitting Workflow - FOLLOW THESE STEPS:
 

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -376,9 +376,16 @@ def evaluate_model(payload: dict) -> dict:
     return response
 
 
+LEGACY_TOOL_NOTE = (
+    "LEGACY TOOL (AxModelFitterLegacy, formerly AxModelFitter): existing workflows built on this toolset "
+    "should continue to use it — it is the unchanged continuation of the original AxModelFitter tools. "
+    "For NEW workflows, prefer the new AxModelFitter server's generate_code/execute_code tools "
+    "(console script `axiomatic-modelfitter`). This legacy toolset will be removed in the next major release.\n\n    "
+)
+
 mcp = FastMCP(
     name="AxModelFitter Legacy Server",
-    instructions="""DEPRECATED: This legacy server will be removed in the next major release. Prefer the new AxModelFitter server (console script `axiomatic-modelfitter`), which generates and executes fitting code directly.
+    instructions="""DEPRECATED: This legacy server will be removed in the next major release. Prefer the new AxModelFitter server (console script `axiomatic-modelfitter`), which generates and executes fitting code directly, for new workflows. Existing workflows built on these tools can keep using this server — the toolset is unchanged; only its registry name changed (AxModelFitter -> AxModelFitterLegacy).
 
     This server provides mathematical model fitting capabilities using the Axiomatic AI platform.
 
@@ -454,7 +461,8 @@ mcp = FastMCP(
 
 @mcp.tool(
     name="fit_model",
-    description="""Fit a custom JAX mathematical model against experimental data.
+    description=LEGACY_TOOL_NOTE
+    + """Fit a custom JAX mathematical model against experimental data.
 
     This tool fits user-defined mathematical models to data using numerical optimization.
     All data MUST be provided via files (CSV, Excel, JSON, Parquet) - no direct data input.
@@ -629,7 +637,7 @@ Use `get_fitting_examples` to see working examples.
 
 @mcp.prompt(
     name="get_workflow_prompt",
-    description="Step-by-step guide for model fitting with the AxModelFitter. Shows complete workflow from model definition to optimization execution.",
+    description="Step-by-step guide for model fitting with this legacy model fitter (AxModelFitterLegacy). Shows complete workflow from model definition to optimization execution.",
 )
 def get_workflow_prompt() -> str:
     """Generate a generic optimization workflow guide."""
@@ -686,7 +694,8 @@ Ready to optimize? Get templates with `get_fitting_examples`!"""
 
 @mcp.tool(
     name="get_fitting_examples",
-    description="""Get complete working examples for model fitting with the AxModelFitter.
+    description=LEGACY_TOOL_NOTE
+    + """Get complete working examples for model fitting with this legacy model fitter.
 
     Returns ready-to-use templates with:
     - Proper JAX function syntax
@@ -1024,7 +1033,8 @@ All templates are generic - adapt the function, parameters, and data to your spe
 
 @mcp.tool(
     name="calculate_information_criteria",
-    description="""Calculate AIC and BIC information criteria for model selection.
+    description=LEGACY_TOOL_NOTE
+    + """Calculate AIC and BIC information criteria for model selection.
 
     REQUIRED INPUTS:
     - loss_value: MSE or MAE value from your optimization
@@ -1297,7 +1307,8 @@ Where ΔAICᵢ = AICᵢ - AIC_best
 
 @mcp.tool(
     name="calculate_r_squared",
-    description="""Calculate R-squared to measure how well your model fits the data.
+    description=LEGACY_TOOL_NOTE
+    + """Calculate R-squared to measure how well your model fits the data.
 
     SIMPLE USAGE:
     - mse: The MSE value from your optimization result
@@ -1396,7 +1407,8 @@ async def calculate_r_squared(
 
 @mcp.tool(
     name="cross_validate_model",
-    description="""Test how well your model generalizes to new data using cross-validation.
+    description=LEGACY_TOOL_NOTE
+    + """Test how well your model generalizes to new data using cross-validation.
 
     REQUIRED INPUTS (same as fit_model):
     - All model parameters: function_source, parameters, bounds, etc.
@@ -1770,7 +1782,8 @@ async def cross_validate_model(
 
 @mcp.tool(
     name="compare_models",
-    description="""Compare multiple models to find the best one using statistical criteria.
+    description=LEGACY_TOOL_NOTE
+    + """Compare multiple models to find the best one using statistical criteria.
 
     USE CASE: You have several competing models (linear, exponential, polynomial) fitted to the same data.
     This tool tells you which model is statistically best.
@@ -2123,7 +2136,8 @@ output_data = {{"columns": ["y"], "name": "y", "unit": "dimensionless"}}
 
 @mcp.tool(
     name="compute_parameter_covariance",
-    description="""Compute parameter covariance matrices for fitted model parameters.
+    description=LEGACY_TOOL_NOTE
+    + """Compute parameter covariance matrices for fitted model parameters.
 
     Provides uncertainty estimates using robust Huber-White sandwich estimator and
     classical inverse Hessian approach. Use after fit_model to quantify parameter

--- a/axiomatic_mcp/servers/axmodelfitter/server.py
+++ b/axiomatic_mcp/servers/axmodelfitter/server.py
@@ -461,8 +461,7 @@ mcp = FastMCP(
 
 @mcp.tool(
     name="fit_model",
-    description=LEGACY_TOOL_NOTE
-    + """Fit a custom JAX mathematical model against experimental data.
+    description=LEGACY_TOOL_NOTE + """Fit a custom JAX mathematical model against experimental data.
 
     This tool fits user-defined mathematical models to data using numerical optimization.
     All data MUST be provided via files (CSV, Excel, JSON, Parquet) - no direct data input.
@@ -694,8 +693,7 @@ Ready to optimize? Get templates with `get_fitting_examples`!"""
 
 @mcp.tool(
     name="get_fitting_examples",
-    description=LEGACY_TOOL_NOTE
-    + """Get complete working examples for model fitting with this legacy model fitter.
+    description=LEGACY_TOOL_NOTE + """Get complete working examples for model fitting with this legacy model fitter.
 
     Returns ready-to-use templates with:
     - Proper JAX function syntax
@@ -1033,8 +1031,7 @@ All templates are generic - adapt the function, parameters, and data to your spe
 
 @mcp.tool(
     name="calculate_information_criteria",
-    description=LEGACY_TOOL_NOTE
-    + """Calculate AIC and BIC information criteria for model selection.
+    description=LEGACY_TOOL_NOTE + """Calculate AIC and BIC information criteria for model selection.
 
     REQUIRED INPUTS:
     - loss_value: MSE or MAE value from your optimization
@@ -1307,8 +1304,7 @@ Where ΔAICᵢ = AICᵢ - AIC_best
 
 @mcp.tool(
     name="calculate_r_squared",
-    description=LEGACY_TOOL_NOTE
-    + """Calculate R-squared to measure how well your model fits the data.
+    description=LEGACY_TOOL_NOTE + """Calculate R-squared to measure how well your model fits the data.
 
     SIMPLE USAGE:
     - mse: The MSE value from your optimization result
@@ -1407,8 +1403,7 @@ async def calculate_r_squared(
 
 @mcp.tool(
     name="cross_validate_model",
-    description=LEGACY_TOOL_NOTE
-    + """Test how well your model generalizes to new data using cross-validation.
+    description=LEGACY_TOOL_NOTE + """Test how well your model generalizes to new data using cross-validation.
 
     REQUIRED INPUTS (same as fit_model):
     - All model parameters: function_source, parameters, bounds, etc.
@@ -1782,8 +1777,7 @@ async def cross_validate_model(
 
 @mcp.tool(
     name="compare_models",
-    description=LEGACY_TOOL_NOTE
-    + """Compare multiple models to find the best one using statistical criteria.
+    description=LEGACY_TOOL_NOTE + """Compare multiple models to find the best one using statistical criteria.
 
     USE CASE: You have several competing models (linear, exponential, polynomial) fitted to the same data.
     This tool tells you which model is statistically best.
@@ -2136,8 +2130,7 @@ output_data = {{"columns": ["y"], "name": "y", "unit": "dimensionless"}}
 
 @mcp.tool(
     name="compute_parameter_covariance",
-    description=LEGACY_TOOL_NOTE
-    + """Compute parameter covariance matrices for fitted model parameters.
+    description=LEGACY_TOOL_NOTE + """Compute parameter covariance matrices for fitted model parameters.
 
     Provides uncertainty estimates using robust Huber-White sandwich estimator and
     classical inverse Hessian approach. Use after fit_model to quantify parameter

--- a/axiomatic_mcp/servers/equations/server.py
+++ b/axiomatic_mcp/servers/equations/server.py
@@ -13,7 +13,7 @@ from ...providers.toolset_provider import get_mcp_tools
 from ...shared.utils.prompt_utils import get_feedback_prompt
 from .services.equations_service import EquationsService
 
-DocumentFields = tuple[str | None, tuple[str, bytes, str] | None]
+DocumentFields = tuple[str | None, bytes | None]
 
 
 def _resolve_path(document: Path | str) -> Path | None:
@@ -32,10 +32,10 @@ def _resolve_path(document: Path | str) -> Path | None:
 
 
 async def _resolve_document(document: Path | str) -> DocumentFields:
-    """Resolve a document into either markdown content or a PDF upload.
+    """Resolve a document into either markdown content or raw PDF bytes.
 
-    Returns a (markdown, pdf_file) tuple where exactly one element is set.
-    PDFs are uploaded directly so the API performs the parsing.
+    Returns a (markdown, pdf_bytes) tuple where exactly one element is set.
+    PDFs are sent to the API (base64-encoded by the service) so it performs the parsing.
     """
     path = _resolve_path(document)
 
@@ -45,7 +45,7 @@ async def _resolve_document(document: Path | str) -> DocumentFields:
     suffix = path.suffix.lower()
     if suffix == ".pdf":
         content = await asyncio.to_thread(path.read_bytes)
-        return None, (path.name, content, "application/pdf")
+        return None, content
     elif suffix in [".md", ".txt"]:
         markdown = await asyncio.to_thread(path.read_text, encoding="utf-8")
         return markdown, None
@@ -73,8 +73,8 @@ async def _run_equation_tool(
 ) -> ToolResult:
     """Shared flow for the equation tools: resolve input, call the API, persist and return."""
     try:
-        markdown, pdf_file = await _resolve_document(document)
-        response = api_call(task=task, markdown=markdown, pdf_file=pdf_file)
+        markdown, pdf_bytes = await _resolve_document(document)
+        response = api_call(task=task, markdown=markdown, pdf_bytes=pdf_bytes)
 
         _write_code_file(document, response.get("code", ""))
 
@@ -92,7 +92,8 @@ async def _run_equation_tool(
 mcp = FastMCP(
     name="AxEquationExplorer Server",
     instructions="""This server provides tools to compose and analyze equations.
-    """ + get_feedback_prompt("find_functional_form, check_equation"),
+    """
+    + get_feedback_prompt("find_functional_form, check_equation"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),

--- a/axiomatic_mcp/servers/equations/server.py
+++ b/axiomatic_mcp/servers/equations/server.py
@@ -92,8 +92,7 @@ async def _run_equation_tool(
 mcp = FastMCP(
     name="AxEquationExplorer Server",
     instructions="""This server provides tools to compose and analyze equations.
-    """
-    + get_feedback_prompt("find_functional_form, check_equation"),
+    """ + get_feedback_prompt("find_functional_form, check_equation"),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),

--- a/axiomatic_mcp/servers/equations/services/equations_service.py
+++ b/axiomatic_mcp/servers/equations/services/equations_service.py
@@ -1,5 +1,6 @@
 """Service for equation derivation and checking API calls."""
 
+import base64
 from typing import Any
 
 from ....shared import AxiomaticAPIClient
@@ -8,48 +9,56 @@ from ....shared.models.singleton_base import SingletonBase
 
 
 class EquationsService(SingletonBase):
-    """Thin proxy service for the equations derive and check endpoints."""
+    """Thin proxy service for the expressions derive and check endpoints."""
 
-    def _build_files(
+    def _build_payload(
         self,
         task: str,
         markdown: str | None = None,
-        pdf_file: tuple[str, bytes, str] | None = None,
+        pdf_bytes: bytes | None = None,
     ) -> dict[str, Any]:
-        """Assemble the multipart/form-data payload expected by the endpoints."""
-        files: dict[str, Any] = {"task": (None, task)}
-        if pdf_file is not None:
-            files["pdf_file"] = pdf_file
+        """Assemble the JSON body expected by the /expressions endpoints.
+
+        Exactly one of markdown or pdf_bytes must be provided; PDFs are sent base64-encoded.
+        """
+        if (markdown is None) == (pdf_bytes is None):
+            raise ValueError("Provide exactly one of 'markdown' or 'pdf_bytes'")
+
+        payload: dict[str, Any] = {"task": task}
         if markdown is not None:
-            files["markdown"] = (None, markdown)
-        return files
+            payload["markdown"] = markdown
+        else:
+            payload["pdf_base64"] = base64.b64encode(pdf_bytes).decode("ascii")
+        return payload
 
     def derive(
         self,
         task: str,
         *,
         markdown: str | None = None,
-        pdf_file: tuple[str, bytes, str] | None = None,
+        pdf_bytes: bytes | None = None,
     ) -> dict[str, Any]:
         """Derive an expression from markdown content or a PDF document.
 
         Returns:
-            dict with keys: explanation, code
+            dict with keys: code, explanation, status
         """
+        payload = self._build_payload(task, markdown=markdown, pdf_bytes=pdf_bytes)
         with AxiomaticAPIClient() as client:
-            return client.post(ApiRoutes.EQUATIONS_DERIVE, files=self._build_files(task, markdown, pdf_file))
+            return client.post(ApiRoutes.EQUATIONS_DERIVE, data=payload)
 
     def check(
         self,
         task: str,
         *,
         markdown: str | None = None,
-        pdf_file: tuple[str, bytes, str] | None = None,
+        pdf_bytes: bytes | None = None,
     ) -> dict[str, Any]:
         """Check the correctness of an equation from markdown content or a PDF document.
 
         Returns:
-            dict with keys: explanation, code
+            dict with keys: code, explanation, status, is_correct
         """
+        payload = self._build_payload(task, markdown=markdown, pdf_bytes=pdf_bytes)
         with AxiomaticAPIClient() as client:
-            return client.post(ApiRoutes.EQUATIONS_CHECK, files=self._build_files(task, markdown, pdf_file))
+            return client.post(ApiRoutes.EQUATIONS_CHECK, data=payload)

--- a/axiomatic_mcp/servers/modelfitter/README.md
+++ b/axiomatic_mcp/servers/modelfitter/README.md
@@ -1,4 +1,4 @@
-# AxModelFitterV2
+# AxModelFitter
 
 An MCP server for fitting parametric models to data using the `ax_core.model_fitter` JAX library.
 
@@ -18,7 +18,7 @@ Add to your MCP client configuration:
 
 ```json
 {
-  "axiomatic-modelfitterv2": {
+  "axiomatic-modelfitter": {
     "command": "uvx",
     "args": ["--from", "axiomatic-mcp", "axiomatic-modelfitter"],
     "env": {
@@ -32,7 +32,7 @@ Add to your MCP client configuration:
 
 ```json
 {
-  "axiomatic-modelfitterv2": {
+  "axiomatic-modelfitter": {
     "command": "python",
     "args": ["-m", "axiomatic_mcp.servers.modelfitter"],
     "env": {

--- a/axiomatic_mcp/servers/modelfitter/__init__.py
+++ b/axiomatic_mcp/servers/modelfitter/__init__.py
@@ -1,5 +1,5 @@
 def main():
-    """Main entry point for the AxModelFitterV2 server."""
+    """Main entry point for the AxModelFitter server."""
     from .server import mcp
 
     mcp.run(transport="stdio")

--- a/axiomatic_mcp/servers/modelfitter/server.py
+++ b/axiomatic_mcp/servers/modelfitter/server.py
@@ -18,7 +18,9 @@ mcp = FastMCP(
         "This server provides tools for fitting parametric models to data using the "
         "ax_core.model_fitter JAX library. Use generate_code to produce executable "
         "fitting code from a problem description, then execute_code to run it in a "
-        "sandboxed environment. Prefer this server over the legacy axmodelfitter server."
+        "sandboxed environment. Prefer this server for new workflows. Existing workflows "
+        "built on the legacy fit_model toolset remain available on the AxModelFitterLegacy "
+        "server (console script `axiomatic-axmodelfitter`) for this release."
     )
     + get_feedback_prompt(["generate_code", "execute_code"]),
     version="0.0.1",

--- a/axiomatic_mcp/servers/modelfitter/server.py
+++ b/axiomatic_mcp/servers/modelfitter/server.py
@@ -13,7 +13,7 @@ from ...shared.utils.prompt_utils import get_feedback_prompt
 from .services.model_fitter_service import ModelFitterService
 
 mcp = FastMCP(
-    name="AxModelFitterV2 Server",
+    name="AxModelFitter Server",
     instructions=(
         "This server provides tools for fitting parametric models to data using the "
         "ax_core.model_fitter JAX library. Use generate_code to produce executable "

--- a/axiomatic_mcp/shared/constants/api_constants.py
+++ b/axiomatic_mcp/shared/constants/api_constants.py
@@ -19,5 +19,5 @@ class ApiRoutes:
     ARGMIN_EXECUTE = "/numerics/argmin/execute"
     MODEL_FITTER_WRITE_CODE = "/numerics/model-fitter/write-code"
     MODEL_FITTER_EXECUTE = "/numerics/model-fitter/execute"
-    EQUATIONS_DERIVE = "/equations/derive"
-    EQUATIONS_CHECK = "/equations/check"
+    EQUATIONS_DERIVE = "/expressions/derive"
+    EQUATIONS_CHECK = "/expressions/check"

--- a/examples/modelfitter/README.md
+++ b/examples/modelfitter/README.md
@@ -1,6 +1,6 @@
 # Model Fitter Examples
 
-Examples for the `AxModelFitterV2` MCP server.
+Examples for the `AxModelFitter` MCP server.
 
 Each folder contains:
 - `prompt.md` — what to ask the agent

--- a/mcp-example.json
+++ b/mcp-example.json
@@ -21,6 +21,13 @@
         "AXIOMATIC_API_KEY": ""
       }
     },
+    "axiomatic-modelfitter": {
+      "command": "uvx",
+      "args": ["--from", "axiomatic-mcp", "axiomatic-modelfitter"],
+      "env": {
+        "AXIOMATIC_API_KEY": ""
+      }
+    },
     "axiomatic-axmodelfitter": {
       "command": "uvx",
       "args": ["--from", "axiomatic-mcp", "axiomatic-axmodelfitter"],

--- a/tests/servers/equations/server_test.py
+++ b/tests/servers/equations/server_test.py
@@ -1,0 +1,113 @@
+"""Tests for the AxEquationExplorer MCP server."""
+
+import base64
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastmcp.client import Client
+
+from axiomatic_mcp.servers.equations.server import mcp
+from axiomatic_mcp.servers.equations.services.equations_service import EquationsService
+from axiomatic_mcp.shared.constants.api_constants import ApiRoutes
+
+SERVICE_CLIENT = "axiomatic_mcp.servers.equations.services.equations_service.AxiomaticAPIClient"
+DERIVE_RESPONSE = {"code": "E = p**2 / (2 * m)", "explanation": "derived from momentum", "status": "SUCCESS"}
+
+
+def _mock_client(mock_client_cls, response):
+    client = mock_client_cls.return_value.__enter__.return_value
+    client.post.return_value = response
+    return client
+
+
+def test_routes_point_at_expressions_endpoints():
+    assert ApiRoutes.EQUATIONS_DERIVE == "/expressions/derive"
+    assert ApiRoutes.EQUATIONS_CHECK == "/expressions/check"
+
+
+def test_derive_with_markdown_sends_json_body():
+    with patch(SERVICE_CLIENT) as mock_client_cls:
+        client = _mock_client(mock_client_cls, DERIVE_RESPONSE)
+        result = EquationsService().derive("derive E from p", markdown="# doc")
+
+    client.post.assert_called_once_with(
+        "/expressions/derive",
+        data={"task": "derive E from p", "markdown": "# doc"},
+    )
+    assert result == DERIVE_RESPONSE
+
+
+def test_derive_with_pdf_sends_base64_json_body():
+    pdf_bytes = b"%PDF-1.4 fake pdf"
+    with patch(SERVICE_CLIENT) as mock_client_cls:
+        client = _mock_client(mock_client_cls, DERIVE_RESPONSE)
+        EquationsService().derive("derive E", pdf_bytes=pdf_bytes)
+
+    client.post.assert_called_once_with(
+        "/expressions/derive",
+        data={"task": "derive E", "pdf_base64": base64.b64encode(pdf_bytes).decode("ascii")},
+    )
+
+
+def test_check_with_markdown_sends_json_body():
+    with patch(SERVICE_CLIENT) as mock_client_cls:
+        client = _mock_client(mock_client_cls, DERIVE_RESPONSE)
+        EquationsService().check("is E=mc^2 correct?", markdown="# doc")
+
+    client.post.assert_called_once_with(
+        "/expressions/check",
+        data={"task": "is E=mc^2 correct?", "markdown": "# doc"},
+    )
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"markdown": "# doc", "pdf_bytes": b"%PDF"}])
+def test_exactly_one_document_source_required(kwargs):
+    # Test _build_payload directly: derive() would also raise ValueError from the
+    # AxiomaticAPIClient constructor when AXIOMATIC_API_KEY is unset (e.g. in CI),
+    # which would make a derive()-based test pass for the wrong reason.
+    with pytest.raises(ValueError, match="exactly one"):
+        EquationsService()._build_payload("task", **kwargs)
+
+
+@pytest_asyncio.fixture
+async def mcp_client():
+    async with Client(transport=mcp) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_list_tools(mcp_client):
+    tools = await mcp_client.list_tools()
+    tool_names = {t.name for t in tools}
+    assert {"find_functional_form", "check_equation"} <= tool_names
+
+
+@pytest.mark.asyncio
+async def test_find_functional_form_with_inline_markdown(mcp_client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch.object(EquationsService, "derive", return_value=DERIVE_RESPONSE) as mock_derive:
+        response = await mcp_client.call_tool(
+            "find_functional_form",
+            {"document": "Momentum is $p = m v$ and energy is $E = \\frac{1}{2} m v^2$.", "task": "express E via p"},
+        )
+
+    mock_derive.assert_called_once_with(
+        task="express E via p",
+        markdown="Momentum is $p = m v$ and energy is $E = \\frac{1}{2} m v^2$.",
+        pdf_bytes=None,
+    )
+    texts = [c.text for c in response.content if hasattr(c, "text")]
+    assert any("derived from momentum" in t for t in texts)
+    assert (tmp_path / "expression_code.py").read_text(encoding="utf-8") == DERIVE_RESPONSE["code"]
+
+
+@pytest.mark.asyncio
+async def test_check_equation_with_pdf_path_passes_raw_bytes(mcp_client, tmp_path):
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake pdf")
+
+    with patch.object(EquationsService, "check", return_value=DERIVE_RESPONSE) as mock_check:
+        await mcp_client.call_tool("check_equation", {"document": str(pdf_path), "task": "check eq 3"})
+
+    mock_check.assert_called_once_with(task="check eq 3", markdown=None, pdf_bytes=b"%PDF-1.4 fake pdf")

--- a/tests/servers/modelfitter/server_test.py
+++ b/tests/servers/modelfitter/server_test.py
@@ -1,8 +1,9 @@
-"""Tests for the AxModelFitterV2 MCP server."""
+"""Tests for the AxModelFitter MCP server."""
+
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
-from unittest.mock import patch
 from fastmcp.client import Client
 
 from axiomatic_mcp.servers.modelfitter.server import mcp

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -20,6 +20,7 @@ wheels = [
 name = "aenum"
 version = "3.1.16"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/7a/61ed58e8be9e30c3fe518899cc78c284896d246d51381bab59b5db11e1f3/aenum-3.1.16.tar.gz", hash = "sha256:bfaf9589bdb418ee3a986d85750c7318d9d2839c1b1a1d6fe8fc53ec201cf140", size = 137693, upload-time = "2026-01-12T22:34:38.819Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/52/6ad8f63ec8da1bf40f96996d25d5b650fdd38f5975f8c813732c47388f18/aenum-3.1.16-py3-none-any.whl", hash = "sha256:9035092855a98e41b66e3d0998bd7b96280e85ceb3a04cc035636138a1943eaf", size = 165627, upload-time = "2025-04-25T03:17:58.89Z" },
 ]
@@ -66,18 +67,6 @@ wheels = [
 ]
 
 [[package]]
-name = "apscheduler"
-version = "3.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzlocal" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/00/6d6814ddc19be2df62c8c898c4df6b5b1914f3bd024b780028caa392d186/apscheduler-3.11.0.tar.gz", hash = "sha256:4c622d250b0955a65d5d0eb91c33e6d43fd879834bf541e0a18661ae60460133", size = 107347, upload-time = "2024-11-24T19:39:26.463Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/ae/9a053dd9229c0fde6b1f1f33f609ccff1ee79ddda364c756a924c6d8563b/APScheduler-3.11.0-py3-none-any.whl", hash = "sha256:fc134ca32e50f5eadcc4938e3a4545ab19131435e851abb40b34d63d5141c6da", size = 64004, upload-time = "2024-11-24T19:39:24.442Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -109,36 +98,42 @@ wheels = [
 
 [[package]]
 name = "axiomatic-mcp"
-version = "0.1.3"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
-    { name = "cspdk" },
-    { name = "debugpy" },
     { name = "fastmcp" },
-    { name = "gdsfactory" },
+    { name = "filetype" },
     { name = "httpx" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "scikit-learn" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "cspdk" },
+    { name = "gdsfactory" },
     { name = "iklayout" },
     { name = "ipympl" },
     { name = "kfactory" },
     { name = "klayout" },
     { name = "klujax" },
-    { name = "moesifasgi" },
+    { name = "leanclient" },
     { name = "nbformat" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "plotly" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
     { name = "sax" },
     { name = "scikit-learn" },
 ]
-
-[package.optional-dependencies]
 dev = [
     { name = "black" },
     { name = "debugpy" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 lean = [
@@ -152,6 +147,7 @@ pic = [
     { name = "kfactory" },
     { name = "klayout" },
     { name = "klujax" },
+    { name = "nbformat" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "plotly" },
@@ -162,44 +158,49 @@ pic = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "cspdk", specifier = ">=1.0.1" },
+    { name = "cspdk", marker = "extra == 'all'", specifier = ">=1.0.1" },
     { name = "cspdk", marker = "extra == 'pic'", specifier = ">=1.0.1" },
-    { name = "debugpy", specifier = ">=1.8.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
-    { name = "fastmcp", specifier = ">=0.1.0" },
-    { name = "gdsfactory", specifier = ">=9.7.0" },
-    { name = "gdsfactory", marker = "extra == 'pic'", specifier = ">=9.7.0" },
+    { name = "fastmcp", specifier = "==2.11.3" },
+    { name = "filetype", specifier = ">=1.2.0" },
+    { name = "gdsfactory", marker = "extra == 'all'", specifier = "==9.11.6" },
+    { name = "gdsfactory", marker = "extra == 'pic'", specifier = "==9.11.6" },
     { name = "httpx", specifier = ">=0.25.0" },
-    { name = "iklayout", specifier = ">=0.0.8" },
+    { name = "iklayout", marker = "extra == 'all'", specifier = ">=0.0.8" },
     { name = "iklayout", marker = "extra == 'pic'", specifier = ">=0.0.8" },
-    { name = "ipympl", specifier = ">=0.9.7" },
+    { name = "ipympl", marker = "extra == 'all'", specifier = ">=0.9.7" },
     { name = "ipympl", marker = "extra == 'pic'", specifier = ">=0.9.7" },
-    { name = "kfactory", specifier = ">=1.7.3" },
+    { name = "kfactory", marker = "extra == 'all'", specifier = ">=1.7.3" },
     { name = "kfactory", marker = "extra == 'pic'", specifier = ">=1.7.3" },
-    { name = "klayout", specifier = ">=0.30.2" },
+    { name = "klayout", marker = "extra == 'all'", specifier = ">=0.30.2" },
     { name = "klayout", marker = "extra == 'pic'", specifier = ">=0.30.2" },
-    { name = "klujax", specifier = ">=0.4.3" },
+    { name = "klujax", marker = "extra == 'all'", specifier = ">=0.4.3" },
     { name = "klujax", marker = "extra == 'pic'", specifier = ">=0.4.3" },
+    { name = "leanclient", marker = "extra == 'all'", specifier = "==0.1.14" },
     { name = "leanclient", marker = "extra == 'lean'", specifier = "==0.1.14" },
-    { name = "moesifasgi", specifier = ">=1.1.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "nbformat", specifier = ">=5.10.4" },
+    { name = "nbformat", marker = "extra == 'all'", specifier = ">=5.10.4" },
+    { name = "nbformat", marker = "extra == 'pic'", specifier = ">=5.10.4" },
     { name = "numpy", specifier = ">=1.21.0" },
+    { name = "numpy", marker = "extra == 'all'", specifier = ">=1.21.0" },
     { name = "numpy", marker = "extra == 'pic'", specifier = ">=1.21.0" },
     { name = "pandas", specifier = ">=1.3.0" },
+    { name = "pandas", marker = "extra == 'all'", specifier = ">=1.3.0" },
     { name = "pandas", marker = "extra == 'pic'", specifier = ">=1.3.0" },
-    { name = "plotly", specifier = ">=6.1.2" },
+    { name = "plotly", marker = "extra == 'all'", specifier = ">=6.1.2" },
     { name = "plotly", marker = "extra == 'pic'", specifier = ">=6.1.2" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "sax", specifier = ">=0.14.5" },
+    { name = "sax", marker = "extra == 'all'", specifier = ">=0.14.5" },
     { name = "sax", marker = "extra == 'pic'", specifier = ">=0.14.5" },
     { name = "scikit-learn", specifier = ">=1.0.0" },
+    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "scikit-learn", marker = "extra == 'pic'", specifier = ">=1.0.0" },
 ]
-provides-extras = ["dev", "lean", "pic"]
+provides-extras = ["dev", "lean", "pic", "all"]
 
 [[package]]
 name = "black"
@@ -518,15 +519,15 @@ wheels = [
 
 [[package]]
 name = "cspdk"
-version = "1.0.9"
+version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "doroutes" },
     { name = "gdsfactory" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/0f2a8a553dda9811bde9182390b93aa564081e27e1a99a605203e4209d60/cspdk-1.0.9.tar.gz", hash = "sha256:94d22766cb7fb756dd7c308e0c790e0971024f0495fa288fa0899979b8f9ad60", size = 261612, upload-time = "2025-08-23T19:57:08.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/e2/e25612e46ffac07115b6d1711a0efc069332197281b43a9f9f01439cd69d/cspdk-1.0.7.tar.gz", hash = "sha256:485aa419f87db984bcd5658cadeb98b890de029c2439537d8cb91ce03640d27c", size = 261612, upload-time = "2025-07-29T15:37:38.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1a/70bfec0400efc27039afcaf726dc436e6bb7e21bfe49c19129c08bd626f2/cspdk-1.0.9-py3-none-any.whl", hash = "sha256:4cbf8706f8d44d4c026c8425965d49a41927d13b521430f977400210576a773e", size = 319056, upload-time = "2025-08-23T19:57:07.076Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/15b6b5aa41b2ce7964bdf13ad0036dac95e070decc55d743667695b55c7f/cspdk-1.0.7-py3-none-any.whl", hash = "sha256:12599e4ac2e7cb7ec58455dcc66a7a6d22f20e30da9bbfb2d4989a0fa3ec6d50", size = 319058, upload-time = "2025-07-29T15:37:37.318Z" },
 ]
 
 [[package]]
@@ -720,6 +721,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
 name = "flax"
 version = "0.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -814,7 +824,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.12.5"
+version = "9.11.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -848,9 +858,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/a8/ebe2c65b6471a11dd175e914096853ee4d73882bfbc43ca152b0cd8663e1/gdsfactory-9.12.5.tar.gz", hash = "sha256:f756831f43c1a9df6f4ebc98b485328ff47c0c53693f806208a04a2bc4297a7c", size = 473633, upload-time = "2025-08-31T04:00:11.07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/c5/f96763db5ea11b57954f4e74b71db2ac47b4d2ccff71a439435966702552/gdsfactory-9.11.6.tar.gz", hash = "sha256:72cd62fe4e27887015f89758d8bb7dd73a7336583c3c015613e8434250e5c8c0", size = 487639, upload-time = "2025-07-27T00:52:50.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/66/e10e89cdd62c8b00b8b37d6b025cca5ea9cdf59a9ad2089d892d3b1611a2/gdsfactory-9.12.5-py3-none-any.whl", hash = "sha256:cb77b8f3087ef1b625ac3217a90ac33030eac64475f1c065a8fc3510d0b95a3d", size = 661771, upload-time = "2025-08-31T04:00:06.92Z" },
+    { url = "https://files.pythonhosted.org/packages/88/24/42571bcf2208728fdad7b52405631e9351e20f1db20e29a2e924fd604099/gdsfactory-9.11.6-py3-none-any.whl", hash = "sha256:76f43e85d9c59e75cbaf9ffd2b5a712591d6118913534561320cac589ea041e2", size = 681201, upload-time = "2025-07-27T00:52:47.848Z" },
 ]
 
 [[package]]
@@ -1299,7 +1309,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "1.13.1"
+version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -1308,7 +1318,6 @@ dependencies = [
     { name = "klayout" },
     { name = "loguru" },
     { name = "pydantic" },
-    { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "rectangle-packer" },
     { name = "requests" },
@@ -1318,9 +1327,9 @@ dependencies = [
     { name = "toolz" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/b0/6ffd5db04cc9bfc44e1ba53b2672f124477604fbacaa5ef418a786c678a7/kfactory-1.13.1.tar.gz", hash = "sha256:4598d9ab50176326ca77f33ac625bcdfbc28372f13f5b0212a7366f01dfafde6", size = 1469509, upload-time = "2025-09-01T07:45:53.392Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/ad/4d647823caed99d4687636313ad988cc89523d6e4636ebdde61adad79aaf/kfactory-1.10.1.tar.gz", hash = "sha256:40a3290502991b10d2a5454154b55eadd03768004e2d2e22e5a683137a129eec", size = 1439655, upload-time = "2025-07-24T17:50:58.112Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/4e/94b1d18a5ddd92e7be8a78e7e06b7da76fd2e363290b1995ce391446c4be/kfactory-1.13.1-py3-none-any.whl", hash = "sha256:0200d5ca7e9d08255d6440a5a0c5897e9e156ffd52d8a2d759a72ff8bb0e7922", size = 230108, upload-time = "2025-09-01T07:45:51.786Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ec/18670fa9471867890f2374179c2433babf381fcddb69ceaa50b3275fbd3c/kfactory-1.10.1-py3-none-any.whl", hash = "sha256:784366c786e7ee3750406c417a5d49ea2c4f2c3a449bcffb3374e5f48f7d4fb2", size = 224806, upload-time = "2025-07-24T17:50:56.751Z" },
 ]
 
 [package.optional-dependencies]
@@ -1783,48 +1792,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/21/783dfb51f40d2660afeb9bccf3612b99f6a803d980d2a09132b0f9d216ab/ml_dtypes-0.5.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:e12e29764a0e66a7a31e9b8bf1de5cc0423ea72979f45909acd4292de834ccd3", size = 689324, upload-time = "2025-07-29T18:39:07.567Z" },
     { url = "https://files.pythonhosted.org/packages/09/f7/a82d249c711abf411ac027b7163f285487f5e615c3e0716c61033ce996ab/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19f6c3a4f635c2fc9e2aa7d91416bd7a3d649b48350c51f7f715a09370a90d93", size = 5275917, upload-time = "2025-07-29T18:39:09.339Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3c/541c4b30815ab90ebfbb51df15d0b4254f2f9f1e2b4907ab229300d5e6f2/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ab039ffb40f3dc0aeeeba84fd6c3452781b5e15bef72e2d10bcb33e4bbffc39", size = 5285284, upload-time = "2025-07-29T18:39:11.532Z" },
-]
-
-[[package]]
-name = "moesifapi"
-version = "1.5.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "apscheduler" },
-    { name = "python-dateutil" },
-    { name = "readerwriterlock" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/7b/2e55a3bc3077ccb936637055d4f00243af53fc3c53f85b2200ad6d5e8a85/moesifapi-1.5.5.tar.gz", hash = "sha256:aece782ec550d34982d0aa02904201e1d609bcc8dfa1cafa665252073b2d4a88", size = 39490, upload-time = "2025-04-23T18:04:43.142Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/8c/b28ac45a26175132cf58e6e1fa94d0dccef93a54b75ad064928632455472/moesifapi-1.5.5-py2.py3-none-any.whl", hash = "sha256:011b305a51e92e1bf21a916920ba5b336f0bd6410f3c1d39bb8a86d6c8024c30", size = 48748, upload-time = "2025-04-23T18:04:41.644Z" },
-]
-
-[[package]]
-name = "moesifasgi"
-version = "1.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "moesifapi" },
-    { name = "moesifpythonrequest" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/9f/759501d478fc3d27ed783a54c4e55d78da89d808766f1f0fe3085dfc9604/moesifasgi-1.1.5.tar.gz", hash = "sha256:ea77e12e8ed4e315af4c6dfc3b142b6a4986a3fb953bc7aca7fc0adc585e905f", size = 24722, upload-time = "2025-04-23T22:18:36.166Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/7d/7c2fee45cbb727c470a23642eef3c07db806e72da8a328974a85ce174271/moesifasgi-1.1.5-py2.py3-none-any.whl", hash = "sha256:cf3d74c10cb243776b517ccca42c603ffe2e3a5235dcb65ae25d1ce6d39ebfa7", size = 21298, upload-time = "2025-04-23T22:18:34.632Z" },
-]
-
-[[package]]
-name = "moesifpythonrequest"
-version = "0.3.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "moesifapi" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/9d/cea8f561f1023f94a23e35c4935bd7aa1b255f03ea3a515396152c2ec452/moesifpythonrequest-0.3.5.tar.gz", hash = "sha256:9a2a1a4af9dbf6265d353d5f47fc6b7b54a23869a8be74782b42a7949aec28c6", size = 17575, upload-time = "2025-07-11T17:11:36.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/76/140d25cec10675a931b33604fc8a9772815754052a55287dbfc535998420/moesifpythonrequest-0.3.5-py2.py3-none-any.whl", hash = "sha256:0a39bedf8daabf8edbe4b03e0e8c343c12ec4de0cea6b0500a7b8284e36c4931", size = 16446, upload-time = "2025-07-11T17:11:35.579Z" },
 ]
 
 [[package]]
@@ -2679,6 +2646,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2839,18 +2819,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
-]
-
-[[package]]
-name = "readerwriterlock"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/b9/6b7c390440ec23bf5fdf33e76d6c3b697a788b983c11cb2739d6541835d6/readerwriterlock-1.0.9.tar.gz", hash = "sha256:b7c4cc003435d7a8ff15b312b0a62a88d9800ba6164af88991f87f8b748f9bea", size = 16595, upload-time = "2021-09-06T03:41:21.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/5a/2f2e7fc026d5e64b5408aa3fbe0296a6407b8481196cae4daacacb3a3ae0/readerwriterlock-1.0.9-py3-none-any.whl", hash = "sha256:8c4b704e60d15991462081a27ef46762fea49b478aa4426644f2146754759ca7", size = 9999, upload-time = "2021-09-06T03:41:19.435Z" },
 ]
 
 [[package]]
@@ -3680,7 +3648,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.17.3"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3688,9 +3656,9 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/82/f4bfed3bc18c6ebd6f828320811bbe4098f92a31adf4040bee59c4ae02ea/typer-0.17.3.tar.gz", hash = "sha256:0c600503d472bcf98d29914d4dcd67f80c24cc245395e2e00ba3603c9332e8ba", size = 103517, upload-time = "2025-08-30T12:35:24.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/78/d90f616bf5f88f8710ad067c1f8705bf7618059836ca084e5bb2a0855d75/typer-0.16.1.tar.gz", hash = "sha256:d358c65a464a7a90f338e3bb7ff0c74ac081449e53884b12ba658cbd72990614", size = 102836, upload-time = "2025-08-18T19:18:22.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/e8/b3d537470e8404659a6335e7af868e90657efb73916ef31ddf3d8b9cb237/typer-0.17.3-py3-none-any.whl", hash = "sha256:643919a79182ab7ac7581056d93c6a2b865b026adf2872c4d02c72758e6f095b", size = 46494, upload-time = "2025-08-30T12:35:22.391Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/76/06dbe78f39b2203d2a47d5facc5df5102d0561e2807396471b5f7c5a30a1/typer-0.16.1-py3-none-any.whl", hash = "sha256:90ee01cb02d9b8395ae21ee3368421faf21fa138cb2a541ed369c08cec5237c9", size = 46397, upload-time = "2025-08-18T19:18:21.663Z" },
 ]
 
 [[package]]
@@ -3730,18 +3698,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
-]
-
-[[package]]
-name = "tzlocal"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes Axiomatic-AI/ax-stack#4044.

## Equations (customer-facing outage)
- `/equations/derive|check` are deprecated and gated to internal/playground users since ax-stack #3622, so external keys got 403s. The MCP now calls `POST /expressions/derive` and `POST /expressions/check` (behind the hierarchical `is_external_user_guard`) with the JSON body they expect: `{task, markdown}` or `{task, pdf_base64}` (PDFs base64-encoded — no more multipart).
- New tests cover payload construction and both tool paths (inline markdown + PDF file), via in-process `fastmcp.client.Client`.

## Model-fitter branding
- The generate_code/execute_code server is now the canonical `AxModelFitter`; the legacy server's registry entry is `AxModelFitterLegacy` (combined-server tool prefixes must stay unique). Domains and both console scripts (`axiomatic-modelfitter`, `axiomatic-axmodelfitter`) keep working this release.
- The legacy server carries a deprecation notice, and every legacy tool description now leads with a LEGACY note: existing workflows keep using `AxModelFitterLegacy`, new workflows use `AxModelFitter` `generate_code`/`execute_code`. The notes live in tool descriptions because `import_server` drops sub-server instructions — descriptions are the only text that reaches the LLM in both standalone and combined modes.
- READMEs/examples swept: zero remaining `V2`/`modelfitterv2` strings; config snippets use the `axiomatic-modelfitter` key matching the real console script; `mcp-example.json` gains the previously missing canonical entry.

## Also in this PR
- Internal version trackers synced to the package version 0.1.17: `axiomatic_mcp/__init__.py:__version__` (was 0.1.3 — this is `serverInfo.version` in the MCP handshake, so 0.1.17 has been introducing itself as 0.1.3 to clients) and `uv.lock`'s self-version (same drift; the refresh also drops stale entries absent from pyproject).

## Release (separate PR to follow)
- No version bump here — the 0.1.18 bump ships in a dedicated release PR.
- Combined-server prefix migration map for those release notes: `AxModelFitter_*` → `AxModelFitterLegacy_*` (legacy tools), `AxModelFitterV2_*` → `AxModelFitter_*` (new tools). Standalone-server users are unaffected (prefixes come from client config keys).
- ⚠️ Live verification against prod with a properly-roled API key is still pending; it gates closing the linked issue, not merging this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Equation API contract and combined-server tool prefixes change behavior for external users and all-in-one MCP clients; legacy fitter tools remain but renamed.
> 
> **Overview**
> **Fixes equation tools for external API keys** by calling `POST /expressions/derive` and `POST /expressions/check` instead of the gated `/equations/*` routes. Requests now use JSON (`task` + `markdown` or base64 `pdf_base64`) rather than multipart uploads; PDF handling passes raw bytes through the server layer.
> 
> **Renames model-fitter MCP branding** so the `generate_code` / `execute_code` server is **AxModelFitter** and the original `fit_model` stack registers as **AxModelFitterLegacy** on the combined server (with deprecation notes on legacy tool descriptions and top-level MCP instructions). Docs, examples, and `mcp-example.json` drop V2 naming and add the canonical `axiomatic-modelfitter` config entry.
> 
> Also syncs package **`__version__` / MCP `serverInfo.version` to 0.1.17** and adds **equation service + MCP tests** for the new payloads and tool paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab47583364cdf1e8758fafb60ea7374bab9cb3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Outstanding validation (gates closing the issue, not merging)

Validated on **staging** (`api.staging.axiomatic-ai.com`, 2026-08-03, INTERNAL-role key):

- [x] `GET /users/me` — 200, role `INTERNAL` (passes the hierarchical `is_external_user_guard`)
- [x] `POST /expressions/derive` (markdown JSON body) — HTTP 200 with `code` / `explanation` / `status: SUCCESS`
- [x] End-to-end through the MCP tools: `find_functional_form` (inline markdown) and `check_equation` (PDF) — both pass

Still open:

- [ ] ⚠️ **IMPORTANT — EXTERNAL-role confirmation on prod.** Repeat the probe against `https://api.axiomatic-ai.com` with a valid prod key, and confirm real customer keys carry the `EXTERNAL` role (the guard is hierarchical, so staging INTERNAL results prove the endpoints, not customer authorization). This is the issue'''s blocking action item for closure.
- [ ] Post-release: uvx-installed package reports the correct `serverInfo.version` in the MCP handshake

