### PR TITLE
fix(meep): stop retrying a permanent 403 in the status poll loop

### DIFF
--- a/axiomatic_mcp/servers/meep/server.py
+++ b/axiomatic_mcp/servers/meep/server.py
@@ -333,9 +333,10 @@ async def _poll_until_terminal(task_id: str, wait_seconds: int) -> tuple[dict[st
         now = time.monotonic()
         expired = now >= deadline
         if _is_failure(response):
-            # A missing task will never appear; a scheduler blip usually passes, and the pod
-            # generally keeps running through it, so only a persistent one is surfaced.
-            if response.get("error_type") == "task_not_found" or expired:
+            # A missing task will never appear and a 403 will never stop being one, so both
+            # are surfaced immediately; a scheduler blip usually passes and the pod generally
+            # keeps running through it, so only a persistent one is surfaced.
+            if response.get("error_type") == "task_not_found" or response.get("status_code") == 403 or expired:
                 return response, now - started
         elif response.get("status") in _TERMINAL_STATUSES or expired:
             return response, now - started

--- a/tests/servers/meep/server_test.py
+++ b/tests/servers/meep/server_test.py
@@ -411,6 +411,17 @@ async def test_get_status_task_not_found_returns_immediately(mcp_client, fast_po
 
 
 @pytest.mark.asyncio
+async def test_get_status_forbidden_returns_immediately(mcp_client, fast_poll):
+    body = {"success": False, "error": "Not authorized", "error_type": "http_error", "status_code": 403}
+
+    with patch.object(MeepService, "get_status", return_value=body) as mock_status:
+        response = await mcp_client.call_tool("get_simulation_status", {"task_id": "job-1", "wait_seconds": 120})
+
+    mock_status.assert_called_once_with("job-1")
+    assert "PLAYGROUND" in _blob(response)
+
+
+@pytest.mark.asyncio
 async def test_get_status_scheduler_error_is_retried_then_reported(mcp_client, fast_poll):
     body = {"success": False, "error": "scheduler unreachable", "error_type": "scheduler_error", "status_code": 502}
 


### PR DESCRIPTION
`_poll_until_terminal` only broke out of its retry loop early on
task_not_found; every other failure, including a 403 from the
playground-access guard, was treated like a transient scheduler blip
and retried until the `wait_seconds` budget expired. Since the guard
never grants access mid-poll, this delayed the access-denied message
by up to 120 seconds and spammed the backend with forbidden requests.

Treat `status_code == 403` as terminal alongside task_not_found, the
same way `_failure_text` already prioritizes it over `error_type` when
rendering guidance to the caller.

Addresses PR review comment:
https://github.com/Axiomatic-AI/ax-mcp/pull/112#discussion_r3842458602

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small poll-loop condition change plus a unit test; no auth logic or API contract changes.
> 
> **Overview**
> `_poll_until_terminal` now treats HTTP **403** as immediately terminal, same as `task_not_found`.
> 
> Previously a playground-access denial was retried like a transient scheduler error until `wait_seconds` expired (up to 120s), delaying the access-denied message and repeating forbidden requests. Scheduler blips still retry until the budget runs out.
> 
> Adds a test that a 403 on `get_simulation_status` returns after a single poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9609f4b3a08aec2ae6f4e640eaaa7783e4aecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->