### PR TITLE
Release 0.1.18: AxPDE, AxMeep, AxKnowledgeBase, AxPaperSearch, AxTidy3D

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -141,12 +141,11 @@ axiomatic-mydomain = "axiomatic_mcp.servers.my_domain:main"
 
 #### Publishing a Release
 
-1. Create a new release branch
-1. Update version in `pyproject.toml`
-1. Commit and push changes
-1. Create a pull request titled "Release: YOUR FEATURE(s)". Include detailed description of what's included in the release.
-1. Create a GitHub release with tag `vX.Y.Z`
-1. GitHub Actions automatically publishes to PyPI
+1. On a new release branch, bump the version in `pyproject.toml` and `axiomatic_mcp/__init__.py`, then run `uv lock` to keep `uv.lock` in sync.
+2. Commit the change with a title of `Release X.Y.Z: <summary of what's included>` and a body describing the notable changes since the last release.
+3. Push the branch and open the pull request — you may reuse the commit's title and body.
+4. Once merged, create a GitHub release with tag `vX.Y.Z`.
+5. GitHub Actions automatically publishes the new version to PyPI.
 
 The package is available at: https://pypi.org/project/axiomatic-mcp/
 

--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Axiomatic MCP Servers - Modular MCP servers built with FastMCP."""
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"
 
 import asyncio
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiomatic-mcp"
-version = "0.1.17"
+version = "0.1.18"
 description = "Modular MCP servers for Axiomatic_AI"
 authors = [{name = "Axiomatic Team", email = "developers@axiomatic-ai.com"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiomatic-mcp"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Includes since 0.1.17: AxModelFitter (execute/generate code tools), AxKnowledgeBase, AxPaperSearch, AxTidy3D, AxPDE, and AxMeep servers, plus equation tool fixes for external users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata and developer documentation only; no runtime or API behavior changes in this diff.
> 
> **Overview**
> **Release 0.1.18** — bumps the package version from **0.1.17** to **0.1.18** in `pyproject.toml`, `axiomatic_mcp/__init__.py`, and `uv.lock` so PyPI/GitHub Actions can publish the build that already includes the servers and fixes noted in the PR description (those changes are not part of this diff).
> 
> **Release docs** in `README.dev.md` are rewritten to match current practice: bump both version files, run **`uv lock`**, use commit/PR titles like **`Release X.Y.Z: …`**, merge before tagging **`vX.Y.Z`**, then rely on CI for PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ab044e092d35d5d0b144dd6da4e513ad95cb31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->