### PR TITLE
feat(kb): add knowledge_graph_read tool required by kg-explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .DS_Store
 *.tsbuildinfo
 config.json
+.idea
 
 # Python
 __pycache__/

--- a/axiomatic_mcp/servers/kb/README.md
+++ b/axiomatic_mcp/servers/kb/README.md
@@ -4,7 +4,7 @@ An MCP server that exposes Axiomatic's curated Knowledge Base — scientific pap
 
 ## Overview
 
-The Knowledge Base server lets AI assistants query Axiomatic's context-curated corpus instead of relying on unsourced recollection of "standard results from the literature". Every search result carries its provenance (paper id/title), so answers can be cited and vetted precisely.
+The Knowledge Base server lets AI assistants query Axiomatic's context-curated corpus instead of relying on unsourced recollection of "standard results from the literature". Every search result carries its provenance (paper id/title), so answers can be cited and vetted precisely. Graph rows are the exception: a Cypher query returns exactly the columns it asks for, so provenance there is the query's job — see `knowledge_graph_read`.
 
 ## Tools Available
 
@@ -34,10 +34,35 @@ Browse the paper corpus directly (paginated), instead of semantic search. Return
 - `page` (int, optional, default 1): page number, starting at 1
 - `page_size` (int, optional, default 20): papers per page (1-100)
 
+### `knowledge_graph_read`
+
+Run one read-only Cypher query against the knowledge graph and get the rows back as a table. Use it when the answer has to be tabular — comparing devices across metrics, building a dataframe, plotting — rather than the prose passages `search_knowledge_base` returns. Call `get_knowledge_base_schema` first for the labels and property names.
+
+**Parameters:**
+
+- `query` (str, required): a read-only Cypher MATCH/RETURN query, aliasing individual properties (`RETURN n.name AS name`, never a bare `RETURN n`)
+- `params` (dict, optional): query parameters, for safe value injection
+
+**Provenance is the query's job.** Rows carry only what the RETURN clause names, so every query should also return the paper each row came from. `Entity`, `Statement` and `Passage` all carry `doc_id`, so the source is one index seek away — no need to walk `HAS_PASSAGE`/`HAS_STATEMENT`/`HAS_ENTITY`:
+
+```cypher
+MATCH (e:Entity) WHERE e.name CONTAINS $term
+MATCH (p:Document {id: e.doc_id})
+RETURN e.name AS name, p.id AS paper_id, p.title AS title
+```
+
+A result with no `paper_id`/`doc_id` column is labelled uncited in the response.
+
+**Keep results small.** The whole result comes back in one MCP response, so return only the properties you need, add an explicit `LIMIT` (100 rows is usually plenty), and never select an `embedding_*` property or bulk `Passage.text`.
+
 **Example Usage:**
 
 ```
 What does our knowledge base say about ring resonator loss mechanisms? Cite your sources.
+```
+
+```
+Table the coupling efficiency of every grating coupler in the knowledge base, with its source paper.
 ```
 
 ## Installation
@@ -79,5 +104,6 @@ What does our knowledge base say about ring resonator loss mechanisms? Cite your
 ## Limitations
 
 - Read-only: no tool writes new content into the knowledge base
-- Structured/advanced querying beyond schema-driven search is not yet exposed here — planned as a follow-up
-- Looking up a specific paper by title, downloading a paper's PDF, and subgraph visualization exist as internal agent tools in ax-stack but aren't exposed here yet — they need new backend endpoints (paper lookup/download aren't REST-exposed today) or a Cypher-free wrapper (visualization currently takes raw Cypher, which we deliberately don't expose)
+- `knowledge_graph_read` enforces provenance only by convention: the response flags rows whose columns don't look like a paper id, but an unusual alias can slip past the check either way. ax-stack traces provenance cell by cell for its own agent tools, but the `/neo4j/execute-read` endpoint doesn't return that trace, so it can't be enforced here
+- The rendered table is bounded — cells over 200 characters are elided and the table stops at 10,000 characters, both stated in the output. The structured result still carries every row in full, so a query selecting long text properties can still produce a large response; keep a `LIMIT` on it
+- Looking up a specific paper by title, downloading a paper's PDF, and subgraph visualization exist as internal agent tools in ax-stack but aren't exposed here yet — they need backend endpoints that don't exist today (paper lookup and download aren't REST-exposed)

--- a/axiomatic_mcp/servers/kb/server.py
+++ b/axiomatic_mcp/servers/kb/server.py
@@ -16,16 +16,18 @@ mcp = FastMCP(
     name="AxKnowledgeBase Server",
     instructions="""This server provides access to Axiomatic's curated knowledge base:
     scientific papers, extracted entities (devices, materials, performance metrics), and
-    passages retrieved via semantic search. Every result carries its source (paper id/title),
-    so it should always be used and cited instead of relying on unsourced recollection of "standard
+    passages retrieved via semantic search. Search results carry their source (paper id/title),
+    so they should always be used and cited instead of relying on unsourced recollection of "standard
     results from the literature". Use search_knowledge_base for semantic/citation lookups,
     get_knowledge_base_schema to discover what entity and relationship types are available,
     get_knowledge_base_overview for corpus-level stats, and list_knowledge_base_papers to
     browse the paper corpus directly. Those four answer in prose; knowledge_graph_read is the
     tabular one — a read-only Cypher query returning entity nodes and their properties as rows,
     for when a passage will not do because the answer has to be a table (comparing entities
-    across metrics, plotting, feeding a dataframe). Call get_knowledge_base_schema first to
-    learn the labels and property names to query.
+    across metrics, plotting, feeding a dataframe). Its rows carry only what the query asks
+    for, so every query must also return the source paper it came from; never present graph
+    values as sourced unless their provenance columns are in the result.
+    Call get_knowledge_base_schema first to learn the labels and property names to query.
     """
     + get_feedback_prompt(
         [
@@ -57,22 +59,52 @@ def _format_search_results(response: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+_MAX_CELL_CHARS = 200
+_MAX_TABLE_CHARS = 10_000
+
+
+def _cell(value: Any) -> str:
+    text = str(value)
+    return text if len(text) <= _MAX_CELL_CHARS else text[:_MAX_CELL_CHARS] + "…"
+
+
 def _format_rows(response: dict[str, Any]) -> str:
-    """Render the row envelope as a table. Rows are shown in full — the endpoint already
-    caps them server-side and says so through `truncated`, and a second cap here would
-    drop data silently."""
+    """Render the row envelope as a table, bounded by a character budget.
+
+    The endpoint caps rows server-side and reports that through `truncated`, but a row cap does
+    not bound response size — a query selecting long text properties blows it up well inside the
+    cap. So cells are elided and the table stops at the budget, both of them visibly. Neither
+    touches the structured result, which still carries every row in full."""
     rows = response.get("rows") or []
     if not rows:
         return "Query returned no rows."
 
     columns = response.get("columns") or list(rows[0].keys())
-    widths = [max(len(str(col)), *(len(str(row.get(col, ""))) for row in rows)) for col in columns]
+    cells = [[_cell(row.get(col, "")) for col in columns] for row in rows]
+    widths = [max(len(str(col)), *(len(cell_row[i]) for cell_row in cells)) for i, col in enumerate(columns)]
     lines = [
         " | ".join(str(col).ljust(w) for col, w in zip(columns, widths, strict=False)),
         "-+-".join("-" * w for w in widths),
     ]
-    lines.extend(" | ".join(str(row.get(col, "")).ljust(w) for col, w in zip(columns, widths, strict=False)) for row in rows)
+    budget = _MAX_TABLE_CHARS
+    for cell_row in cells:
+        line = " | ".join(cell.ljust(w) for cell, w in zip(cell_row, widths, strict=False))
+        budget -= len(line) + 1
+        if budget < 0:
+            break
+        lines.append(line)
+    shown = len(lines) - 2
     lines.append(f"\n{response.get('count', len(rows))} row(s).")
+    if shown < len(rows):
+        lines.append(
+            f"Table stopped after {shown} row(s) at the response size budget; the rest are in the "
+            "structured result only. Narrow the query or drop long text properties from the RETURN."
+        )
+    if not any("paper" in str(col).lower() or "doc" in str(col).lower() for col in columns):
+        lines.append(
+            "No provenance column in these rows — they are uncited. Re-run the query joining each "
+            "entity to its source Paper and returning paper_id/title before presenting the values."
+        )
     if response.get("truncated"):
         lines.append("Truncated at the server row limit — narrow the query to see the rest.")
     return "\n".join(lines)
@@ -224,7 +256,19 @@ async def list_knowledge_base_papers(
         "Always alias individual properties in the RETURN clause; never return raw node or "
         "relationship objects (avoid `RETURN n`, write `RETURN n.name AS name`). For "
         "relationship queries, alias the source and target as `from` and `to` so the result "
-        "renders as a graph."
+        "renders as a graph.\n\n"
+        "Rows carry no provenance of their own, so every query must also return the paper each "
+        "row came from. Entity, Statement and Passage nodes all carry `doc_id`, so the source is "
+        "one index seek away — no need to walk the HAS_PASSAGE/HAS_STATEMENT/HAS_ENTITY chain:\n"
+        "  MATCH (e:Entity) WHERE e.name CONTAINS $term\n"
+        "  MATCH (p:Document {id: e.doc_id})\n"
+        "  RETURN e.name AS name, p.id AS paper_id, p.title AS title\n"
+        "Values returned without a paper_id (or doc_id) column are uncited and must not be "
+        "presented as sourced results.\n\n"
+        "The whole result comes back in one response, so keep it small: return only the "
+        "properties you need, add an explicit LIMIT (100 rows is usually plenty), and never "
+        "select an `embedding_*` property or bulk `Passage.text` — long values are elided from "
+        "the table, and the query is cheaper written narrowly than trimmed afterwards."
     ),
     tags=["knowledge-base", "graph", "cypher"],
 )

--- a/axiomatic_mcp/servers/kb/server.py
+++ b/axiomatic_mcp/servers/kb/server.py
@@ -21,7 +21,11 @@ mcp = FastMCP(
     results from the literature". Use search_knowledge_base for semantic/citation lookups,
     get_knowledge_base_schema to discover what entity and relationship types are available,
     get_knowledge_base_overview for corpus-level stats, and list_knowledge_base_papers to
-    browse the paper corpus directly.
+    browse the paper corpus directly. Those four answer in prose; knowledge_graph_read is the
+    tabular one — a read-only Cypher query returning entity nodes and their properties as rows,
+    for when a passage will not do because the answer has to be a table (comparing entities
+    across metrics, plotting, feeding a dataframe). Call get_knowledge_base_schema first to
+    learn the labels and property names to query.
     """
     + get_feedback_prompt(
         [
@@ -29,6 +33,7 @@ mcp = FastMCP(
             "get_knowledge_base_schema",
             "get_knowledge_base_overview",
             "list_knowledge_base_papers",
+            "knowledge_graph_read",
         ]
     ),
     version="0.0.1",
@@ -49,6 +54,27 @@ def _format_search_results(response: dict[str, Any]) -> str:
         metadata = result.get("metadata") or {}
         source = metadata.get("paper_title") or metadata.get("paper_id") or "unknown source"
         lines.append(f"{i}. [source: {source}, score={result.get('score') or 0:.3f}]\n{result.get('text', '')}\n")
+    return "\n".join(lines)
+
+
+def _format_rows(response: dict[str, Any]) -> str:
+    """Render the row envelope as a table. Rows are shown in full — the endpoint already
+    caps them server-side and says so through `truncated`, and a second cap here would
+    drop data silently."""
+    rows = response.get("rows") or []
+    if not rows:
+        return "Query returned no rows."
+
+    columns = response.get("columns") or list(rows[0].keys())
+    widths = [max(len(str(col)), *(len(str(row.get(col, ""))) for row in rows)) for col in columns]
+    lines = [
+        " | ".join(str(col).ljust(w) for col, w in zip(columns, widths, strict=False)),
+        "-+-".join("-" * w for w in widths),
+    ]
+    lines.extend(" | ".join(str(row.get(col, "")).ljust(w) for col, w in zip(columns, widths, strict=False)) for row in rows)
+    lines.append(f"\n{response.get('count', len(rows))} row(s).")
+    if response.get("truncated"):
+        lines.append("Truncated at the server row limit — narrow the query to see the rest.")
     return "\n".join(lines)
 
 
@@ -183,5 +209,36 @@ async def list_knowledge_base_papers(
 
     return ToolResult(
         content=[TextContent(type="text", text="\n".join(lines))],
+        structured_content=response,
+    )
+
+
+@mcp.tool(
+    name="knowledge_graph_read",
+    description=(
+        "Execute a read-only Cypher query against the knowledge graph and return the rows. "
+        "Use this when the answer has to be a table of entities and their properties — "
+        "comparing devices across metrics, building a dataframe, plotting — rather than the "
+        "prose passages search_knowledge_base returns. Only MATCH/RETURN is permitted. Call "
+        "get_knowledge_base_schema first to learn the available labels and property names.\n\n"
+        "Always alias individual properties in the RETURN clause; never return raw node or "
+        "relationship objects (avoid `RETURN n`, write `RETURN n.name AS name`). For "
+        "relationship queries, alias the source and target as `from` and `to` so the result "
+        "renders as a graph."
+    ),
+    tags=["knowledge-base", "graph", "cypher"],
+)
+async def knowledge_graph_read(
+    query: Annotated[str, "A read-only Cypher MATCH/RETURN query, aliasing specific properties"],
+    params: Annotated[dict[str, Any] | None, "Optional query parameters, for safe value injection"] = None,
+) -> ToolResult:
+    """Read entity nodes and their properties out of the knowledge graph."""
+    try:
+        response = knowledge_base_service.execute_read(query, params)
+    except Exception as e:
+        raise ToolError(f"Failed to read the knowledge graph: {e!s}") from e
+
+    return ToolResult(
+        content=[TextContent(type="text", text=_format_rows(response))],
         structured_content=response,
     )

--- a/axiomatic_mcp/servers/kb/services/knowledge_base_service.py
+++ b/axiomatic_mcp/servers/kb/services/knowledge_base_service.py
@@ -46,6 +46,22 @@ class KnowledgeBaseService(SingletonBase):
         with AxiomaticAPIClient() as client:
             return client.get(ApiRoutes.KNOWLEDGE_BASE_OVERVIEW)
 
+    def execute_read(self, query: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """
+        Run one read-only Cypher query against the knowledge graph.
+
+        The endpoint enforces read-only, a server-side query timeout and a row cap, and
+        reports the cap through `truncated` rather than by failing.
+
+        Returns:
+            dict with keys: schema_kind, columns, rows, count, truncated
+        """
+        with AxiomaticAPIClient() as client:
+            return client.post(
+                ApiRoutes.KNOWLEDGE_BASE_EXECUTE_READ,
+                data={"query": query, "params": params},
+            )
+
     def list_papers(self, page: int = 1, page_size: int = 20) -> dict[str, Any]:
         """
         List papers ingested into the knowledge base, paginated.

--- a/axiomatic_mcp/shared/constants/api_constants.py
+++ b/axiomatic_mcp/shared/constants/api_constants.py
@@ -17,6 +17,7 @@ class ApiRoutes:
     KNOWLEDGE_BASE_GET_SCHEMA = "/neo4j/get-schema"
     KNOWLEDGE_BASE_OVERVIEW = "/neo4j/overview"
     KNOWLEDGE_BASE_LIST_PAPERS = "/neo4j/papers"
+    KNOWLEDGE_BASE_EXECUTE_READ = "/neo4j/execute-read"
     ARXIV_SEARCH_WORKS = "/search/arxiv/works"
     OPENALEX_SEARCH_WORKS = "/search/openalex/works"
     TIDY3D_GENERATE_CODE = "/tidy3d/generate-code"

--- a/tests/servers/kb/server_test.py
+++ b/tests/servers/kb/server_test.py
@@ -203,3 +203,46 @@ async def test_knowledge_graph_read_passes_params_through(mcp_client):
         )
 
     spy.assert_called_once_with("MATCH (d {name: $n}) RETURN d.name AS name", {"n": "SiN GC"})
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_read_flags_missing_provenance(mcp_client):
+    """Cypher rows only carry what the query returned, so an uncited result set has to say so —
+    otherwise the model presents graph numbers as sourced literature values."""
+    uncited = {"schema_kind": "table", "columns": ["name", "ce_dB"], "rows": [{"name": "SiN GC", "ce_dB": -1.2}], "count": 1}
+    cited = {
+        "schema_kind": "table",
+        "columns": ["name", "paper_id"],
+        "rows": [{"name": "SiN GC", "paper_id": "2301.07041"}],
+        "count": 1,
+    }
+
+    with patch.object(KnowledgeBaseService, "execute_read", return_value=uncited):
+        response = await mcp_client.call_tool("knowledge_graph_read", {"query": "MATCH (n) RETURN n.name AS name"})
+    assert "uncited" in "\n".join(c.text for c in response.content if hasattr(c, "text"))
+
+    with patch.object(KnowledgeBaseService, "execute_read", return_value=cited):
+        response = await mcp_client.call_tool("knowledge_graph_read", {"query": "MATCH (n) RETURN n.name AS name"})
+    assert "uncited" not in "\n".join(c.text for c in response.content if hasattr(c, "text"))
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_read_bounds_response_size(mcp_client):
+    """The endpoint's row cap is not a size cap — 500 rows of passage text is megabytes. The
+    table elides long cells and stops at a character budget; the structured result keeps all of it."""
+    long_text = "x" * 5000
+    mock_response = {
+        "schema_kind": "table",
+        "columns": ["paper_id", "text"],
+        "rows": [{"paper_id": f"p{i}", "text": long_text} for i in range(50)],
+        "count": 50,
+    }
+
+    with patch.object(KnowledgeBaseService, "execute_read", return_value=mock_response):
+        response = await mcp_client.call_tool("knowledge_graph_read", {"query": "MATCH (p:Passage) RETURN p.text AS text"})
+
+    text = "\n".join(c.text for c in response.content if hasattr(c, "text"))
+    assert long_text not in text
+    assert "Table stopped after" in text
+    assert len(text) < 15_000
+    assert response.structured_content["rows"][0]["text"] == long_text

--- a/tests/servers/kb/server_test.py
+++ b/tests/servers/kb/server_test.py
@@ -25,6 +25,7 @@ async def test_list_tools(mcp_client):
         "get_knowledge_base_schema",
         "get_knowledge_base_overview",
         "list_knowledge_base_papers",
+        "knowledge_graph_read",
     } <= tool_names
 
 
@@ -130,3 +131,75 @@ async def test_list_knowledge_base_papers_no_results(mcp_client):
 
     texts = [c.text for c in response.content if hasattr(c, "text")]
     assert any("No papers found on page 5" in t for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_read_renders_rows_as_a_table(mcp_client):
+    mock_response = {
+        "schema_kind": "table",
+        "columns": ["name", "ce_dB", "bw_nm"],
+        "rows": [
+            {"name": "Apodized SOI grating coupler", "ce_dB": -0.8, "bw_nm": 38.8},
+            {"name": "Curved LNOI grating coupler", "ce_dB": -3.9, "bw_nm": 90.0},
+        ],
+        "count": 2,
+        "truncated": False,
+    }
+
+    with patch.object(KnowledgeBaseService, "execute_read", return_value=mock_response) as spy:
+        response = await mcp_client.call_tool(
+            "knowledge_graph_read",
+            {"query": "MATCH (d:GratingCoupler) RETURN d.name AS name"},
+        )
+
+    spy.assert_called_once_with("MATCH (d:GratingCoupler) RETURN d.name AS name", None)
+    text = "\n".join(c.text for c in response.content if hasattr(c, "text"))
+    # Header, both rows and the count all have to survive the formatter: the whole point of
+    # this tool over search_knowledge_base is that the caller gets every row, as a table.
+    assert "name" in text and "ce_dB" in text and "bw_nm" in text
+    assert "Apodized SOI grating coupler" in text
+    assert "Curved LNOI grating coupler" in text
+    assert "2 row(s)" in text
+    assert response.structured_content == mock_response
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_read_reports_server_side_truncation(mcp_client):
+    """`truncated` is the endpoint's row cap. Swallowing it would read as a complete answer."""
+    mock_response = {
+        "schema_kind": "table",
+        "columns": ["name"],
+        "rows": [{"name": f"device {i}"} for i in range(3)],
+        "count": 3,
+        "truncated": True,
+    }
+
+    with patch.object(KnowledgeBaseService, "execute_read", return_value=mock_response):
+        response = await mcp_client.call_tool("knowledge_graph_read", {"query": "MATCH (n) RETURN n.name AS name"})
+
+    text = "\n".join(c.text for c in response.content if hasattr(c, "text"))
+    assert "Truncated" in text
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_read_no_rows(mcp_client):
+    mock_response = {"schema_kind": "table", "columns": [], "rows": [], "count": 0, "truncated": False}
+
+    with patch.object(KnowledgeBaseService, "execute_read", return_value=mock_response):
+        response = await mcp_client.call_tool("knowledge_graph_read", {"query": "MATCH (n:Nope) RETURN n.name AS name"})
+
+    text = "\n".join(c.text for c in response.content if hasattr(c, "text"))
+    assert "no rows" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_read_passes_params_through(mcp_client):
+    mock_response = {"schema_kind": "table", "columns": ["name"], "rows": [{"name": "SiN GC"}], "count": 1, "truncated": False}
+
+    with patch.object(KnowledgeBaseService, "execute_read", return_value=mock_response) as spy:
+        await mcp_client.call_tool(
+            "knowledge_graph_read",
+            {"query": "MATCH (d {name: $n}) RETURN d.name AS name", "params": {"n": "SiN GC"}},
+        )
+
+    spy.assert_called_once_with("MATCH (d {name: $n}) RETURN d.name AS name", {"n": "SiN GC"})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Exposes arbitrary read-only graph queries to API clients; misuse or broad RETURN clauses can still yield large payloads despite table elision, and citation safety relies on heuristic column checks rather than server-side provenance traces.
> 
> **Overview**
> Adds **`knowledge_graph_read`** to the AxKnowledgeBase MCP server so assistants can run **read-only Cypher** against the graph and get **tabular** results (for comparisons, dataframes, plots) instead of semantic passage search.
> 
> The tool calls a new backend route (`/neo4j/execute-read`) via `KnowledgeBaseService.execute_read`, returns full rows in **structured content**, and formats a bounded text table (200-char cells, ~10k-char table budget) with notes for **server row truncation**, **missing paper/doc provenance columns**, and guidance in tool text/README to join `Document` via `doc_id` and keep queries small.
> 
> Server instructions, feedback tool list, README limitations, `.gitignore` (`.idea`), and KB server tests for formatting, params, truncation, provenance flags, and size bounds are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f19c615b2d5a5bec0393de1fe11a7584a0d10dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->