### PR TITLE
Update argmin mcp with verification transport

### DIFF
--- a/axiomatic_mcp/servers/argmin/server.py
+++ b/axiomatic_mcp/servers/argmin/server.py
@@ -1,27 +1,206 @@
-from typing import Annotated
+"""AxArgmin MCP server — generate and run argmin numerical solves."""
+
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
-from mcp.types import TextContent
+from mcp.types import ContentBlock, TextContent
 
 from ...providers.middleware_provider import get_mcp_middleware
 from ...providers.toolset_provider import get_mcp_tools
 from ...shared.utils.prompt_utils import get_feedback_prompt
 from .services.argmin_service import ArgminService
 
+INSTRUCTIONS = """\
+This server provides tools for numerical optimization, rootfinding, ODE simulation, and optimal control
+using the argmin library. Use generate_code to produce executable code from a problem description,
+then execute_code to run it in a sandboxed environment.
+
+READING A RESULT: `success` says only that the code RAN. Whether the *answers* are solved is reported
+separately, in the `verification` payload execute_code returns alongside the exports. A diverged or
+infeasible solve runs perfectly cleanly and comes back with `success: true`.
+
+- `verification._summary.all_passed` is the flag to read. It is true only when every exported solve both
+  converged and produced a certificate that passed at the requested tolerances.
+- Where the two disagree, the `Verification:` line in the tool's text output wins over the raw flag in the
+  structured result. That line is not a copy of `all_passed`: it reports a pass only when the payload also
+  counted at least one solve AND counted none as failed or unverified. So a payload claiming a pass over
+  nothing checked, or claiming one beside a non-zero `n_failed`/`n_unknown`, is reported as unverified
+  rather than certified. Nothing is hidden — the full payload is in the structured result either way.
+- `verification._warnings` names findings: what did not check out, and by how much, per export. It may also
+  carry an advisory that does not bear on the verdict — an export name colliding with a reserved key, say —
+  so a warning is not by itself a failure. The `Verification:` line is what says whether it mattered.
+- Each entry also carries the `certificate` (the KKT / residual / integration-accuracy check re-evaluated
+  at the point actually returned) and, on failure, a `diagnosis` whose `kind` names the failure class and
+  whose `suggestion` says what to change. Pass those on to the user rather than only that it failed.
+
+When a solve does not verify, do NOT report its numbers as the answer, and do not quietly simplify the
+problem until something converges — dropping constraints or coarsening the discretisation yields a
+confident answer to a different question. Fix the formulation or the solver settings, or report the failure.
+
+To get a certificate back, the generated code only has to export the result object itself
+(`export('result', result)`); the certificate and diagnosis travel with it.
+"""
+
 mcp = FastMCP(
     name="AxArgmin Server",
-    instructions="""This server provides tools for numerical optimization, rootfinding, ODE simulation, and optimal control
-    using the argmin library. Use generate_code to produce executable code from a problem description,
-    then execute_code to run it in a sandboxed environment.
-    """ + get_feedback_prompt(["generate_code", "execute_code"]),
+    instructions=INSTRUCTIONS + get_feedback_prompt(["generate_code", "execute_code"]),
     version="0.0.1",
     middleware=get_mcp_middleware(),
     tools=get_mcp_tools(),
 )
 
 argmin_service = ArgminService()
+
+# No `output_schema` here, deliberately. fastmcp builds the client's `.data` from the
+# declared schema, keeping only what the schema names: declaring one for `verification`
+# reduced `.data` to `_summary` and `_warnings` and dropped every per-export certificate
+# and diagnosis — the payload this tool exists to deliver. An `additionalProperties`
+# clause did not save the nested entries either, and constraining it to objects made a
+# reserved key of any other type fail validation outright, taking the whole call with it.
+# The backend types this field `dict[str, Any]` precisely so new certificate fields reach
+# callers without an SDK or MCP release; a JSON Schema here fights that. The shape is
+# documented in the tool description and the server instructions instead, which is where
+# a model reads it anyway.
+_NOTHING_EXPORTED_TEXT = (
+    "Verification: none. No export carried a solver result, so no certificate came back and nothing about "
+    "this answer has been checked. Export the result object itself — export('result', result) — and the "
+    "certificate travels with it."
+)
+_BACKEND_TOO_OLD_TEXT = (
+    "Verification: unavailable. A solver result was exported, but this deployment of the argmin executor "
+    "predates the certificate payload, so the answer has not been independently checked. The code is fine — "
+    "do not rewrite it. Read the solver result in the exports — its own `success` and `status` fields — and "
+    "say the answer is unverified when you report it."
+)
+
+# A serialized solver result is recognised by the fields every argmin result carries, rather
+# than by its export name, which the generated code chooses freely.
+_SOLVER_RESULT_MARKERS = ("success", "status")
+# The executor walks containers to find results; so must this, or a multistart export
+# (a list of results, a dict of per-start records) reads as "nothing was exported".
+# Bounded so that a long trajectory export cannot make the scan expensive.
+_EXPORT_SCAN_DEPTH = 3
+
+
+def _text(message: str) -> TextContent:
+    return TextContent(type="text", text=message)
+
+
+def _count(value: Any) -> int:
+    """A count from the payload, or 0 when it is missing or not a whole number.
+
+    Accepts 2.0 as well as 2: the field is typed `dict[str, Any]` backend-side and JSON
+    makes no distinction, so rejecting the float would silently downgrade a genuinely
+    verified pass to "inconclusive". A fractional count is not a count, and fails closed.
+    """
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return 0
+
+
+def _exported_a_solver_result(exports: Any, _depth: int = 0) -> bool:
+    """Whether anything in the exports is a serialized solver result.
+
+    Never tests the exports mapping itself (`_depth` 0): code that calls
+    `export('success', ...)` and `export('status', ...)` separately — the optimal-control
+    examples do — would otherwise make the whole mapping look like one result.
+    """
+    if _depth and isinstance(exports, dict) and all(marker in exports for marker in _SOLVER_RESULT_MARKERS):
+        return True
+    if _depth >= _EXPORT_SCAN_DEPTH:
+        return False
+    if isinstance(exports, dict):
+        children: Any = exports.values()
+    elif isinstance(exports, (list, tuple)):
+        children = exports
+    else:
+        return False
+    return any(_exported_a_solver_result(child, _depth + 1) for child in children)
+
+
+def _verification_text(verification: Any, exports: Any = None) -> str:
+    """One block saying whether the answers are solved, not merely whether the code ran.
+
+    Reporting only, never blocking: a failed certificate is described here and does not turn the
+    call into an error. Solves that fail are a normal part of working a problem, and raising would
+    throw away the exports, the diagnosis and the certificate — exactly what the caller needs to
+    fix it.
+    """
+    if not isinstance(verification, dict) or not verification:
+        # A missing payload has two causes the response cannot tell apart, and telling an agent
+        # the wrong one is costly: "export the result" sends it rewriting code that was already
+        # correct. Attribute it from the exports instead — a current executor walking an exported
+        # result object always produces a payload, so a serialized solver result sitting next to a
+        # missing payload can only be the older backend.
+        return _BACKEND_TOO_OLD_TEXT if _exported_a_solver_result(exports) else _NOTHING_EXPORTED_TEXT
+
+    summary = verification.get("_summary")
+    summary = summary if isinstance(summary, dict) else {}
+    checked = _count(summary.get("n_verifiable"))
+    warnings = verification.get("_warnings")
+    warnings = warnings if isinstance(warnings, list) else []
+
+    failed = _count(summary.get("n_failed"))
+    unknown = _count(summary.get("n_unknown"))
+
+    # Computed BEFORE the pass branch, so a self-inconsistent payload cannot be certified
+    # on its flag alone. `all_passed` is defined backend-side as `n_failed == 0 and
+    # n_unknown == 0`, so a true flag beside a positive count is a contradiction, and the
+    # safe reading of a contradiction about whether an answer is solved is that it is not.
+    #
+    # A warning is deliberately NOT disqualifying. `_warnings_for` returns nothing for a
+    # passing entry, so per-entry lines are findings — but the reserved-key collision
+    # warning is emitted whether or not the colliding export passed, so an advisory beside
+    # a clean run is a real shape today. Downgrading on it would fail a legitimate pass;
+    # instead the advisory is carried into the pass text rather than swallowed.
+    contradicts_a_pass = failed or unknown
+
+    if summary.get("all_passed") is True and checked > 0 and not contradicts_a_pass:
+        passed_lines = [
+            f"Verification: passed. All {checked} exported solve(s) converged and satisfied their certificate " f"at the requested tolerances."
+        ]
+        if warnings:
+            passed_lines.append("The payload also notes:")
+            passed_lines.extend(f"  - {warning}" for warning in warnings)
+        return "\n".join(passed_lines)
+
+    # Anything the payload says went wrong is a finding, even when the counts are missing
+    # or a shape this server does not know. Falling back to "inconclusive" here would drop
+    # the warnings naming what missed and by how much, and with them the instruction not to
+    # report the numbers -- the strongest thing this block says, lost exactly when it applies.
+    states_a_failure = summary.get("all_passed") is False or contradicts_a_pass or warnings
+    if not states_a_failure:
+        return (
+            "Verification: inconclusive. A payload came back but reports no checked solve and no finding, so "
+            "nothing about this answer has been certified. Treat it as unverified and say so when you report it."
+        )
+
+    # Phrased from what is actually known: "of 3 checked solve(s) 0 failed and 0 produced
+    # none" would contradict the headline it sits under when a warning drove the verdict.
+    if failed or unknown:
+        counts = (
+            f"of {checked} checked solve(s) {failed} failed their certificate and {unknown} produced none"
+            if checked > 0
+            else f"{failed} solve(s) failed their certificate and {unknown} produced none"
+        )
+    elif checked > 0:
+        counts = f"none of the {checked} checked solve(s) is counted as failed, though the payload reports findings"
+    else:
+        counts = "the payload reports findings without counting them"
+    lines = [f"Verification: NOT passed. The code ran, but {counts}."]
+    lines.extend(f"  - {warning}" for warning in warnings)
+    lines.append(
+        "Do not report these numbers as the answer, and do not simplify the problem until it converges. "
+        "Read `verification` in the structured result for each certificate and diagnosis — `diagnosis.suggestion` "
+        "says what to change — then fix the formulation or the solver settings and re-run."
+    )
+    return "\n".join(lines)
 
 
 @mcp.tool(
@@ -55,13 +234,13 @@ async def generate_code(
         raise ToolError(f"Failed to generate code: {e!s}") from e
 
     if response.get("error"):
-        return ToolResult(content=[TextContent(type="text", text=f"Code generation failed: {response['error']}")])
+        return ToolResult(content=[_text(f"Code generation failed: {response['error']}")])
 
-    content = []
+    content: list[ContentBlock] = []
     if response.get("explanation"):
-        content.append(TextContent(type="text", text=response["explanation"]))
+        content.append(_text(response["explanation"]))
     if response.get("code"):
-        content.append(TextContent(type="text", text=f"```python\n{response['code']}\n```"))
+        content.append(_text(f"```python\n{response['code']}\n```"))
 
     return ToolResult(
         content=content,
@@ -74,7 +253,10 @@ async def generate_code(
     description=(
         "Execute Python code in a sandboxed environment with numpy, math, and the ax_core.argmin "
         "numerical library available. Code must call export(name, value) at least once to return results. "
-        "Typically used to run code produced by the generate_code tool, but also accepts hand-written or modified code."
+        "Typically used to run code produced by the generate_code tool, but also accepts hand-written or modified code. "
+        "Returns the exports plus a `verification` payload holding the certificate and diagnosis of every exported "
+        "solver result: `success` reports only that the code ran, so read the `Verification:` line in the response "
+        "to learn whether the answers are solved."
     ),
     tags=["argmin", "execution", "sandbox"],
 )
@@ -93,14 +275,26 @@ async def execute_code(
         text = f"Execution failed: {error_msg}"
         if stdout:
             text += f"\n\nStdout:\n{stdout}"
-        return ToolResult(content=[TextContent(type="text", text=text)])
+        failed: list[ContentBlock] = [_text(text)]
+        # Today the executor only attaches a payload to a run that completed, so there is
+        # nothing to report here. Conditional rather than absent so that if a partial
+        # failure ever carries one, its certificates reach the model instead of being
+        # dropped on the floor by this branch.
+        if isinstance(response.get("verification"), dict) and response["verification"]:
+            failed.append(_text(_verification_text(response["verification"], response.get("result"))))
+        return ToolResult(content=failed, structured_content=response)
 
-    parts = []
+    # The verdict leads, so it frames the numbers that follow rather than trailing them:
+    # a diverged solve returns `success: true` with empty trajectories, and read in the
+    # other order the exports look like an answer.
+    parts: list[ContentBlock] = [_text(_verification_text(response.get("verification"), response.get("result")))]
     if response.get("result"):
-        parts.append(TextContent(type="text", text=f"Result: {response['result']}"))
+        parts.append(_text(f"Result: {response['result']}"))
     if response.get("stdout"):
-        parts.append(TextContent(type="text", text=f"Stdout:\n{response['stdout']}"))
-    parts.append(TextContent(type="text", text=f"Execution time: {response.get('execution_time', 0):.3f}s"))
+        parts.append(_text(f"Stdout:\n{response['stdout']}"))
+    execution_time = response.get("execution_time")
+    if isinstance(execution_time, (int, float)) and not isinstance(execution_time, bool):
+        parts.append(_text(f"Execution time: {execution_time:.3f}s"))
 
     return ToolResult(
         content=parts,

--- a/axiomatic_mcp/servers/argmin/services/argmin_service.py
+++ b/axiomatic_mcp/servers/argmin/services/argmin_service.py
@@ -38,7 +38,12 @@ class ArgminService(SingletonBase):
             code: Python code to execute. Must call export(name, value).
 
         Returns:
-            dict with keys: success, result, error, stdout, execution_time
+            dict with keys: success, result, error, stdout, execution_time, verification.
+
+            `success` reports only that the code ran. `verification` carries the certificate and
+            diagnosis of every exported solver result, and is None when no export carried one --
+            the shape is documented in the execute_code tool description and in INSTRUCTIONS
+            in ../server.py.
         """
         with AxiomaticAPIClient() as client:
             return client.post(

--- a/tests/servers/argmin/server_test.py
+++ b/tests/servers/argmin/server_test.py
@@ -1,0 +1,591 @@
+"""Tests for the AxArgmin MCP server.
+
+Focused on the `verification` payload: `success` reports only that the generated code ran,
+so whether the *answers* are solved reaches the caller through this field and nowhere else.
+A payload that arrived but went unmentioned in the tool's text would be a silent regression
+-- the model reads the content blocks, not the structured result -- so the wording is
+asserted here alongside the pass-through.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastmcp.client import Client
+
+from axiomatic_mcp.servers.argmin.server import _verification_text, mcp
+from axiomatic_mcp.servers.argmin.services.argmin_service import ArgminService
+from axiomatic_mcp.shared.constants.api_constants import ApiRoutes
+
+SERVICE_CLIENT = "axiomatic_mcp.servers.argmin.services.argmin_service.AxiomaticAPIClient"
+
+
+def _certificate(passed: bool) -> dict:
+    return {
+        "kkt_stationarity_inf": 3.5e-10 if passed else 3.0,
+        "constraint_violation_upper": 0.0,
+        "tolerances": {"tol": 1e-08},
+        "passed": passed,
+        "primal_finite": True,
+    }
+
+
+def _verified_response() -> dict:
+    return {
+        "success": True,
+        "result": {"result": {"success": True, "status": "Solve_Succeeded", "objective_value": 0.5}},
+        "error": None,
+        "stdout": None,
+        "execution_time": 0.42,
+        "verification": {
+            "_summary": {"all_passed": True, "n_verifiable": 1, "n_passed": 1, "n_failed": 0, "n_unknown": 0},
+            "_warnings": [],
+            "result": {
+                "passed": True,
+                "solver_success": True,
+                "solver_status": "Solve_Succeeded",
+                "certificate": _certificate(True),
+                "diagnosis": None,
+            },
+        },
+    }
+
+
+def _unverified_response() -> dict:
+    return {
+        "success": True,
+        "result": {"result": {"success": False, "status": "Infeasible_Problem_Detected", "objective_value": None}},
+        "error": None,
+        "stdout": None,
+        "execution_time": 0.18,
+        "verification": {
+            "_summary": {"all_passed": False, "n_verifiable": 1, "n_passed": 0, "n_failed": 1, "n_unknown": 0},
+            "_warnings": ["result: KKT stationarity 3 exceeds tol 1e-08"],
+            "result": {
+                "passed": False,
+                "solver_success": False,
+                "solver_status": "Infeasible_Problem_Detected",
+                "certificate": _certificate(False),
+                "diagnosis": {
+                    "kind": "infeasible_detected",
+                    "solver_return_status": "Infeasible_Problem_Detected",
+                    "message": "Infeasible problem detected",
+                    "suggestion": "Check constraints for contradictions or relax bounds.",
+                },
+            },
+        },
+    }
+
+
+def _mock_client(mock_client_cls, response):
+    client = mock_client_cls.return_value.__enter__.return_value
+    client.post.return_value = response
+    return client
+
+
+def _texts(response) -> list[str]:
+    return [block.text for block in response.content if hasattr(block, "text")]
+
+
+def _blob(response) -> str:
+    return "\n".join(_texts(response))
+
+
+@pytest_asyncio.fixture
+async def mcp_client():
+    async with Client(transport=mcp) as client:
+        yield client
+
+
+# ── routes and registration ──────────────────────────────────────────────────
+
+
+def test_routes_point_at_argmin_endpoints():
+    assert ApiRoutes.ARGMIN_WRITE_CODE == "/numerics/argmin/write-code"
+    assert ApiRoutes.ARGMIN_EXECUTE == "/numerics/argmin/execute"
+
+
+@pytest.mark.asyncio
+async def test_list_tools(mcp_client):
+    tool_names = {t.name for t in await mcp_client.list_tools()}
+    assert {"generate_code", "execute_code"} <= tool_names
+
+
+@pytest.mark.asyncio
+async def test_execute_declares_no_output_schema(mcp_client):
+    """The absence is the guarantee — see the comment above `_NOTHING_EXPORTED_TEXT`.
+
+    fastmcp derives the client's `.data` from a declared schema and keeps only what the
+    schema names, so any schema here silently deletes the per-export certificates. Asserted
+    rather than left to a comment because adding one back looks like an improvement.
+    """
+    tools = {t.name: t for t in await mcp_client.list_tools()}
+    assert tools["execute_code"].outputSchema is None
+
+
+@pytest.mark.asyncio
+async def test_the_certificate_survives_all_the_way_into_client_data(mcp_client):
+    """`.data` is what a fastmcp client reads; the evidence has to be there, not just in the raw dict."""
+    body = _verified_response()
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    assert response.data == body
+    assert response.data["verification"]["result"]["certificate"]["kkt_stationarity_inf"] == 3.5e-10
+    assert response.data["result"]["result"]["objective_value"] == 0.5
+
+
+def test_instructions_tell_the_client_where_the_verdict_lives():
+    assert "all_passed" in mcp.instructions
+    assert "says only that the code RAN" in mcp.instructions
+
+
+def test_instructions_describe_the_verdict_the_code_actually_produces():
+    """The model-facing contract has to match `_verification_text`, not trail it.
+
+    These two claims drifted behind the code twice: the precedence rule listed only one of
+    the reasons a pass is refused, and the `_warnings` line still called every warning a
+    finding after the advisory case was established. Both are asserted against the behaviour
+    rather than the wording alone, so the next change to one has to update the other.
+    """
+    instructions = mcp.instructions
+    advisory = ["export '_summary' collides with a reserved verification key"]
+
+    # Claim: a pass is refused when nothing was counted, AND when a count contradicts the flag.
+    assert "n_failed" in instructions and "n_unknown" in instructions
+    assert _verification_text({"_summary": {"all_passed": True, "n_verifiable": 0}}).startswith("Verification: inconclusive")
+    assert _verification_text({"_summary": {"all_passed": True, "n_verifiable": 3, "n_failed": 1}}).startswith("Verification: NOT passed")
+
+    # Claim: a warning is not by itself a failure, and the verdict line says whether it mattered.
+    assert "not by itself a failure" in instructions
+    clean_with_advisory = _verification_text(
+        {"_summary": {"all_passed": True, "n_verifiable": 1, "n_failed": 0, "n_unknown": 0}, "_warnings": advisory}
+    )
+    assert clean_with_advisory.startswith("Verification: passed")
+    assert advisory[0] in clean_with_advisory
+
+
+# ── service layer ────────────────────────────────────────────────────────────
+
+
+def test_generate_code_sends_json_body():
+    with patch(SERVICE_CLIENT) as mock_client_cls:
+        client = _mock_client(mock_client_cls, {"code": "c", "explanation": "e", "error": None})
+        ArgminService().generate_code("minimize x^2", "nonlinear_program")
+
+    client.post.assert_called_once_with(
+        "/numerics/argmin/write-code",
+        data={"problem_description": "minimize x^2", "problem_type": "nonlinear_program"},
+    )
+
+
+def test_execute_code_sends_json_body():
+    with patch(SERVICE_CLIENT) as mock_client_cls:
+        client = _mock_client(mock_client_cls, _verified_response())
+        ArgminService().execute_code("export('x', 1)")
+
+    client.post.assert_called_once_with("/numerics/argmin/execute", data={"code": "export('x', 1)"})
+
+
+# ── generate_code ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_generate_code_rejects_an_unknown_problem_type(mcp_client):
+    with pytest.raises(Exception, match="Invalid problem_type"):
+        await mcp_client.call_tool("generate_code", {"problem_description": "x^2", "problem_type": "quantum"})
+
+
+@pytest.mark.asyncio
+async def test_generate_code_returns_the_code_block(mcp_client):
+    body = {"code": "export('x', 1)", "explanation": "square it", "error": None}
+
+    with patch.object(ArgminService, "generate_code", return_value=body):
+        response = await mcp_client.call_tool("generate_code", {"problem_description": "minimize x^2", "problem_type": "nonlinear_program"})
+
+    assert "square it" in _blob(response)
+    assert "```python\nexport('x', 1)\n```" in _blob(response)
+
+
+# ── execute_code: the verification payload ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verified_solve_says_so_and_passes_the_payload_through(mcp_client):
+    body = _verified_response()
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    assert "Verification: passed" in _texts(response)[0]
+    assert response.structured_content == body
+
+
+@pytest.mark.asyncio
+async def test_a_failed_solve_is_reported_without_being_turned_into_an_error(mcp_client):
+    """Report, don't block: the code ran, so the exports and the diagnosis must survive."""
+    body = _unverified_response()
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    assert not response.is_error
+    verdict = _texts(response)[0]
+    assert "Verification: NOT passed" in verdict
+    assert "KKT stationarity 3 exceeds tol 1e-08" in verdict
+    assert "Do not report these numbers as the answer" in verdict
+    assert response.structured_content["verification"]["result"]["diagnosis"]["kind"] == "infeasible_detected"
+
+
+@pytest.mark.asyncio
+async def test_the_verdict_is_read_before_the_numbers(mcp_client):
+    """A diverged solve returns success=true; in the other order the exports read as an answer."""
+    with patch.object(ArgminService, "execute_code", return_value=_unverified_response()):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    texts = _texts(response)
+    assert texts[0].startswith("Verification:")
+    assert any(text.startswith("Result:") for text in texts[1:])
+
+
+@pytest.mark.asyncio
+async def test_nothing_verifiable_is_named_as_such_not_reported_as_a_pass(mcp_client):
+    """`verification: null` must never read as "checked and fine"."""
+    body = {"success": True, "result": {"x": 2.0}, "error": None, "stdout": None, "execution_time": 0.01, "verification": None}
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('x', 2.0)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: none" in verdict
+    assert "passed" not in verdict.lower().split("export(")[0]
+    assert "export('result', result)" in verdict
+
+
+@pytest.mark.asyncio
+async def test_an_older_backend_is_not_blamed_on_the_generated_code(mcp_client):
+    """The key is simply absent against a backend that predates the payload.
+
+    Reported live against the deployed API today, so this is the common path, not a corner
+    case. The exports hold a solver result, which a current executor would always have
+    reported on -- so telling the agent to "export the result" would send it rewriting code
+    that was already correct.
+    """
+    body = {
+        "success": True,
+        "result": {"result": {"success": True, "status": "Solve_Succeeded", "objective_value": 0.5}},
+        "error": None,
+        "stdout": None,
+        "execution_time": 0.01,
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: unavailable" in verdict
+    assert "do not rewrite it" in verdict
+    assert "export('result', result)" not in verdict
+
+
+@pytest.mark.asyncio
+async def test_a_missing_payload_with_no_solver_result_still_blames_the_code(mcp_client):
+    """The other side of the same discrimination: nothing was exported to check."""
+    body = {"success": True, "result": {"x": 2.0}, "error": None, "stdout": None, "execution_time": 0.01}
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('x', 2.0)"})
+
+    assert "Verification: none" in _texts(response)[0]
+
+
+@pytest.mark.asyncio
+async def test_a_stated_failure_without_counts_is_still_a_failure(mcp_client):
+    """The payload is an open object; a shape this server does not know must not crash it.
+
+    `all_passed: false` says the answer is not solved, so the counts being absent must not
+    soften that into "inconclusive" — the reader still needs to be told not to use it.
+    """
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {"_summary": {"all_passed": False}, "_warnings": []},
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: NOT passed" in verdict
+    assert "Do not report these numbers as the answer" in verdict
+
+
+@pytest.mark.asyncio
+async def test_findings_survive_a_payload_with_no_summary_at_all(mcp_client):
+    """The warnings ARE the finding; an inconclusive verdict would throw them away.
+
+    A payload carrying per-export entries and `_warnings` but no `_summary` is the most
+    plausible unknown shape, and it is exactly the one where the detail matters most.
+    """
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {
+            "_warnings": ["result: KKT stationarity 3 exceeds tol 1e-08"],
+            "result": {"passed": False, "diagnosis": {"kind": "diverged"}},
+        },
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: NOT passed" in verdict
+    assert "KKT stationarity 3 exceeds tol 1e-08" in verdict
+    assert "Do not report these numbers as the answer" in verdict
+
+
+@pytest.mark.asyncio
+async def test_failure_counts_without_a_total_are_reported_coherently(mcp_client):
+    """No `n_verifiable`, so the sentence must not read "of 0 checked solve(s) 2 failed"."""
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {"_summary": {"all_passed": False, "n_failed": 2}, "_warnings": []},
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: NOT passed" in verdict
+    assert "2 solve(s) failed their certificate" in verdict
+    assert "of 0 checked" not in verdict
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("counts", [{"n_failed": 1}, {"n_unknown": 1}])
+async def test_a_pass_flag_beside_a_failure_count_is_not_a_pass(mcp_client, counts):
+    """`all_passed` is defined backend-side as n_failed == 0 and n_unknown == 0.
+
+    A true flag beside a positive count is a contradiction, and the safe reading of a
+    contradiction about whether an answer is solved is that it is not. Without this the
+    warning line, the certificate and the diagnosis are all dropped and the answer goes
+    out certified.
+    """
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {
+            "_summary": {"all_passed": True, "n_verifiable": 3, "n_passed": 2, **counts},
+            "_warnings": ["result_b: KKT stationarity 3.0 exceeds tol 1e-08"],
+            "result_b": {"passed": False, "diagnosis": {"kind": "infeasible_detected"}},
+        },
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: NOT passed" in verdict
+    assert "Verification: passed" not in verdict
+    assert "KKT stationarity 3.0 exceeds tol 1e-08" in verdict
+    assert "Do not report these numbers as the answer" in verdict
+
+
+@pytest.mark.asyncio
+async def test_an_advisory_warning_does_not_downgrade_a_clean_run(mcp_client):
+    """Not every warning is a finding, so a warning alone must not fail a passing solve.
+
+    `_warnings_for` returns nothing for a passing entry, but the backend also emits a
+    reserved-key collision warning whether or not the colliding export passed -- an
+    advisory beside a clean run is a real shape. It is carried into the pass text rather
+    than swallowed, so the reader still sees it.
+    """
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {
+            "_summary": {"all_passed": True, "n_verifiable": 1, "n_passed": 1, "n_failed": 0, "n_unknown": 0},
+            "_warnings": ["export '_summary' collides with a reserved verification key"],
+        },
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: passed" in verdict
+    assert "collides with a reserved verification key" in verdict
+
+
+@pytest.mark.asyncio
+async def test_a_warning_driven_verdict_does_not_contradict_its_own_counts(mcp_client):
+    """No failure is counted, so the sentence must not read "0 failed ... 0 produced none"."""
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {"_summary": {"n_verifiable": 3}, "_warnings": ["result_b: diverged"]},
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: NOT passed" in verdict
+    assert "none of the 3 checked solve(s) is counted as failed" in verdict
+    assert "0 failed their certificate" not in verdict
+
+
+@pytest.mark.asyncio
+async def test_a_non_dict_payload_on_a_failed_run_is_not_called_a_stale_backend(mcp_client):
+    """The two gates must agree on what counts as a payload, or they contradict each other."""
+    body = {"success": False, "result": None, "error": "boom", "verification": "not a dict"}
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export("})
+
+    blob = _blob(response)
+    assert "Execution failed: boom" in blob
+    assert "predates the certificate payload" not in blob
+
+
+@pytest.mark.asyncio
+async def test_an_empty_payload_naming_nothing_is_inconclusive(mcp_client):
+    """Nothing counted and nothing reported: the one case that really is inconclusive."""
+    body = {"success": True, "result": {"result": {}}, "execution_time": 0.1, "verification": {"_summary": {}, "_warnings": []}}
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    assert "Verification: inconclusive" in _texts(response)[0]
+
+
+@pytest.mark.asyncio
+async def test_a_count_json_spelled_as_a_float_still_counts(mcp_client):
+    """`2` and `2.0` are the same number in JSON; rejecting the float downgrades a real pass."""
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {"_summary": {"all_passed": True, "n_verifiable": 2.0}, "_warnings": []},
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    assert "Verification: passed. All 2 exported solve(s)" in _texts(response)[0]
+
+
+@pytest.mark.asyncio
+async def test_a_pass_over_nothing_is_not_reported_as_a_pass(mcp_client):
+    """`all_passed` true with no counted solve certifies nothing, whatever the flag says.
+
+    The whole feature exists to stop an unchecked answer being reported as certified, so
+    the one claim a caller acts on is not made on the strength of a single flag in a
+    payload built to keep growing.
+    """
+    body = {
+        "success": True,
+        "result": {"result": {}},
+        "execution_time": 0.1,
+        "verification": {"_summary": {"all_passed": True, "n_verifiable": 0}, "_warnings": []},
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('result', result)"})
+
+    verdict = _texts(response)[0]
+    assert "Verification: inconclusive" in verdict
+    assert "Verification: passed" not in verdict
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "verification",
+    ["a string", 42, ["a", "list"], {"_summary": "not a dict"}, {"_summary": {"all_passed": True, "n_verifiable": None}}],
+)
+async def test_an_unknown_payload_shape_never_raises(mcp_client, verification):
+    """Documented as open and unknown-tolerant, so it has to actually tolerate the unknown."""
+    body = {"success": True, "result": {"x": 1.0}, "execution_time": 0.1, "verification": verification}
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('x', 1.0)"})
+
+    assert not response.is_error
+    assert _texts(response)[0].startswith("Verification:")
+
+
+@pytest.mark.asyncio
+async def test_a_null_execution_time_does_not_break_the_response(mcp_client):
+    """The backend types this field nullable; formatting None with :.3f raises TypeError."""
+    body = {"success": True, "result": {"x": 1.0}, "execution_time": None, "verification": None}
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('x', 1.0)"})
+
+    assert not response.is_error
+    assert not any("Execution time" in text for text in _texts(response))
+
+
+@pytest.mark.asyncio
+async def test_a_nested_solver_result_counts_as_exported(mcp_client):
+    """A multistart exports a list of results; that is a result reaching the caller too.
+
+    Checking only top-level exports would tell the agent it exported nothing verifiable --
+    the exact wrong instruction this discrimination exists to avoid.
+    """
+    body = {
+        "success": True,
+        "result": {"runs": [{"success": True, "status": "Solve_Succeeded"}, {"success": False, "status": "Infeasible"}]},
+        "execution_time": 0.1,
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('runs', runs)"})
+
+    assert "Verification: unavailable" in _texts(response)[0]
+
+
+@pytest.mark.asyncio
+async def test_scalar_success_and_status_exports_are_not_mistaken_for_a_result(mcp_client):
+    """The optimal-control examples export `success` and `status` as separate scalars.
+
+    The exports mapping would then carry both marker keys itself, and treating it as a
+    result would claim a stale backend on code that really did export nothing verifiable.
+    """
+    body = {
+        "success": True,
+        "result": {"success": True, "status": "Solve_Succeeded", "optimal_time": 1.2},
+        "execution_time": 0.1,
+    }
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export('success', result.success)"})
+
+    assert "Verification: none" in _texts(response)[0]
+
+
+# ── execute_code: the code itself failing ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_code_that_did_not_run_reports_the_error(mcp_client):
+    body = {"success": False, "result": None, "error": "SyntaxError: invalid syntax", "stdout": "partial\n"}
+
+    with patch.object(ArgminService, "execute_code", return_value=body):
+        response = await mcp_client.call_tool("execute_code", {"code": "export("})
+
+    blob = _blob(response)
+    assert "Execution failed: SyntaxError: invalid syntax" in blob
+    assert "partial" in blob
+    # No verdict line: nothing ran, so there is nothing to have verified.
+    assert "Verification:" not in blob
+    assert response.structured_content == body


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes agent-facing contracts for argmin execution (verdict semantics, error vs result, and MCP payload shape); regressions could mislead models about solve correctness or strip certificate data from clients.
> 
> **Overview**
> The AxArgmin MCP server now treats **`success` as “the code ran”** and exposes a leading **`Verification:`** line (plus expanded server instructions and `execute_code` docs) so agents do not treat diverged or infeasible runs as certified answers.
> 
> **`execute_code` response shape** changes materially: the verdict text comes first; the full API body (including per-export certificates and diagnoses) is returned as **structured content and a JSON text block** instead of a Python `repr` of exports. **`execute_code` intentionally has no `output_schema`** so fastmcp clients keep the full open `verification` dict in `.data`. When the sandbox reports the code did not run (`success: false`), the tool **raises `ToolError`** (with stdout, optional verification text, and embedded JSON) so hosts see `isError`—while completed runs with failed certificates still return normally with diagnosis intact.
> 
> A large **`tests/servers/argmin/server_test.py`** suite locks in verdict wording, JSON recoverability, certificate-only vs solver-verdict cases, malformed summaries, and error vs unverified distinctions. **`ArgminService.execute_code`** docstring documents the new `verification` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56017b409d69d4125c80a704d1ed6f0b3e81f794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->