### PR TITLE
Release 0.1.19: access to private kb

### DIFF
--- a/axiomatic_mcp/__init__.py
+++ b/axiomatic_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Axiomatic MCP Servers - Modular MCP servers built with FastMCP."""
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"
 
 import asyncio
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiomatic-mcp"
-version = "0.1.18"
+version = "0.1.19"
 description = "Modular MCP servers for Axiomatic_AI"
 authors = [{name = "Axiomatic Team", email = "developers@axiomatic-ai.com"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiomatic-mcp"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
AxKnowledgeBase now supports a private knowledge graph.

Alongside the existing read-only curated corpus, users can ingest their own PDFs into an organization-specific graph via ingest_pdf_to_private_knowledge_base, then search and query it with private counterparts of the existing tools (search_private_knowledge_base, get_private_knowledge_base_overview, private_knowledge_graph_read). 

Ingested papers stay isolated from the curated corpus and are only ever reachable through these private-graph tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile metadata only; no runtime logic changes in the diff.
> 
> **Overview**
> Cuts release **0.1.19** by bumping the package version from `0.1.18` to **`0.1.19`** in `axiomatic_mcp/__init__.py`, `pyproject.toml`, and the `axiomatic-mcp` entry in `uv.lock` (lockfile `revision` goes from 2 to 3).
> 
> No application or MCP tool code changes appear in this diff—only version and lock metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539a491692fa3f2ab356b320e90ab893bb86902f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->